### PR TITLE
Made reactor a mandatory arg

### DIFF
--- a/lib/WorkerWatcher.php
+++ b/lib/WorkerWatcher.php
@@ -18,8 +18,8 @@ class WorkerWatcher {
     private $isReloading = false;
     private $lastWorkerId = 0;
 
-    public function __construct(Reactor $reactor = null) {
-        $this->reactor = $reactor ?: \Amp\getReactor();
+    public function __construct(Reactor $reactor) {
+        $this->reactor = $reactor;
     }
 
     public function watch($options) {


### PR DESCRIPTION
To prevent unit test problems with mixed reactor instances
