### PR TITLE
use instead of namespace

### DIFF
--- a/doc/tls-encryption.md
+++ b/doc/tls-encryption.md
@@ -103,7 +103,7 @@ Aerys utilizes the SNI TLS extension to serve multiple encrypted hosts on the sa
 ```php
 <?php
 
-namespace Aerys;
+use Aerys\Host;
 
 $domain1 = (new Host)
     ->setName('domain1.com')


### PR DESCRIPTION
A example app should have its own namespace
