### PR TITLE
Request documentation update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ You can read this documentation either directly on GitHub or on our website. Whi
 
 Setup shared parts with [`git submodules`](https://git-scm.com/docs/git-submodule) from root directory:
 
-```shell
+```bash
 # initialize your local configuration file 
 git submodule init
 
@@ -22,7 +22,7 @@ git submodule update
 
 Our documentation is built using [Jekyll](https://jekyllrb.com/). To install it, run following commands:
 
-```shell
+```bash
 # Go to docs folder
 cd docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory contains the documentation for `amphp/aerys`. Documentation and code are bundled within a single repository for easier maintenance. Additionally, this preserves the documentation for older versions.
+This directory contains the documentation for `amphp/http-server`. Documentation and code are bundled within a single repository for easier maintenance. Additionally, this preserves the documentation for older versions.
 
 ## Reading
 
@@ -8,13 +8,32 @@ You can read this documentation either directly on GitHub or on our website. Whi
 
 ## Writing
 
-Our documentation is built using Jekyll.
+`amphp/http-server`, as all [`amphp`](https://github.com/amphp) documentation, depends on shared parts from main [amphp.org](https://github.com/amphp/amphp.github.io) website repository. 
 
+Setup shared parts with [`git submodules`](https://git-scm.com/docs/git-submodule) from root directory:
+
+```shell
+# initialize your local configuration file 
+git submodule init
+
+# fetch all the data from amphp/amphp.github.io project
+git submodule update
 ```
+
+Our documentation is built using [Jekyll](https://jekyllrb.com/). To install it, run following commands:
+
+```shell
+# Go to docs folder
+cd docs
+
+# Install Jekyll and Bundler gems through RubyGems
 sudo gem install bundler jekyll
-```
 
-```
+# Install required dependencies
 bundle install --path vendor/bundle
+
+# Build the site on the preview server
 bundle exec jekyll serve
+
+# Now browse to http://localhost:4000/http-server/
 ```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ exclude: ["Gemfile", "Gemfile.lock", "README.md", "vendor"]
 safe: true
 
 repository: amphp/http-server
-gems:
+plugins:
  - "jekyll-github-metadata"
  - "jekyll-relative-links"
 

--- a/docs/classes/index.md
+++ b/docs/classes/index.md
@@ -2,24 +2,16 @@
 title: Classes
 permalink: /classes/
 ---
-Aerys provides a set of classes and interfaces, as well as [functions](functions.md):
+The `http-server` package provides a set of classes and interfaces, as well as [functions](functions.md):
 
-- [`BodyParser`](bodyparser.md) &mdash; Parser for bodies
-- [`Bootable`](bootable.md) &mdash; Registers entry point for [`Server`](server.md) and [`Logger`](logger.md)
 - [`Client`](client.md) &mdash; Client connection related information
-- [`CommandClient`](commandclient.md) &mdash; Controls the server master process
-- [`FieldBody`](fieldbody.md) &mdash; Field body message container (via [`BodyParser`](bodyparser.md))
-- [`Filter`](filter.md) &mdash; Defines a filter callable in `do()` method
-- [`Host`](host.md) &mdash; Registers a virtual host
 - [`HttpDriver`](httpdriver.md) &mdash; Driver for interaction with the raw socket
-- [`InternalRequest`](internalrequest.md) &mdash; Request related information
 - [`Logger`](logger.md) &mdash; PSR-3 compatible logger
+- [`Message`](message.md) &mdash; An abstract class represents HTTP message
 - [`Options`](options.md) &mdash; Accessor of options
-- [`ParsedBody`](parsedbody.md) &mdash; Holds request body data in parsed form
-- [`Request`](request.md) &mdash; General request interface for responder callables
+- [`Request`](request.md) &mdash; Request class for request handler callables
+- [`RequestBody`](request-body.md) &mdash; Request body
+- [`RequestHandler`](request-handler.md) &mdash; Request handler interface 
 - [`Response`](response.md) &mdash; General response interface for responder callables
-- [`Router`](router.md) &mdash; Manages and accumulates routes
 - [`Server`](server.md) &mdash; The server, tying everything together
 - [`ServerObserver`](serverobserver.md) &mdash; Registers method to be notified upon Server state changes
-- [`Websocket`](websocket.md) &mdash; General websocket connection manager
-- [`Websocket\Endpoint`](websocket-endpoint.md) &mdash; Provides API to communicate with a websocket client

--- a/docs/classes/message.md
+++ b/docs/classes/message.md
@@ -1,0 +1,10 @@
+---
+title: Message
+permalink: /classes/message
+---
+# Message
+
+Abstract class **`Message`**
+
+{% include undocumented.md %}
+

--- a/docs/classes/request-body.md
+++ b/docs/classes/request-body.md
@@ -1,0 +1,10 @@
+---
+title: RequestBody
+permalink: /classes/request-body
+---
+# Message
+
+Final class **`RequestBody`** extends [`Payload`](https://amphp.org/byte-stream/payload)
+
+{% include undocumented.md %}
+

--- a/docs/classes/request-handler.md
+++ b/docs/classes/request-handler.md
@@ -1,0 +1,10 @@
+---
+title: RequestHandler
+permalink: /classes/request-handler
+---
+# RequestHandler
+
+Interface **`RequestHandler`**
+
+{% include undocumented.md %}
+

--- a/src/Request.php
+++ b/src/Request.php
@@ -68,21 +68,21 @@ class Request extends Message {
     }
 
     /**
-     * Sets the request HTTP method.
-     *
-     * @param string $method
-     */
-    public function setMethod(string $method) {
-        $this->method = $method;
-    }
-
-    /**
      * Retrieve the HTTP method used to make this request.
      *
      * @return string
      */
     public function getMethod(): string {
         return $this->method;
+    }
+
+    /**
+     * Sets the request HTTP method.
+     *
+     * @param string $method
+     */
+    public function setMethod(string $method) {
+        $this->method = $method;
     }
 
     /**
@@ -235,7 +235,7 @@ class Request extends Message {
     }
 
     /**
-     * Adds a cookie to the response.
+     * Adds a cookie to the request.
      *
      * @param RequestCookie $cookie
      */
@@ -245,7 +245,7 @@ class Request extends Message {
     }
 
     /**
-     * Removes a cookie from the response.
+     * Removes a cookie from the request.
      *
      * @param string $name
      */


### PR DESCRIPTION
PR for #242:

1. Updated Jekyll config (`gems` -> `plugins`)
2. Updated `docs/README.md`: `git submodule` explanation added
3. Removed links to missing classes in `docs/classes/index.md`
4. Added stubs for new `docs/classes/message.md`, `docs/classes/requestbody.md` and `docs/classes/requesthandler.md`
5. Updated `docs/classes/request.md`
6. Changed the order of setter and getter of HTTP method (to keep it consistent)