### PR TITLE
Convert convertible types to string on setBody()

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -89,12 +89,18 @@ final class Response extends Internal\Message {
             return;
         }
 
-        if ($stringOrStream !== null && !\is_string($stringOrStream)) {
+        try {
+            // Use method with string type declaration, so we don't need to implement our own check.
+            $this->setBodyFromString($stringOrStream ?? "");
+        } catch (\TypeError $e) {
+            // Provide a better error message in case of a failure.
             throw new \TypeError("The response body must a string, null, or instance of " . InputStream::class);
         }
+    }
 
-        $this->body = new InMemoryStream($stringOrStream);
-        $this->setHeader("content-length", (string) \strlen($stringOrStream));
+    private function setBodyFromString(string $body) {
+        $this->body = new InMemoryStream($body);
+        $this->setHeader("content-length", (string) \strlen($body));
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -124,14 +124,24 @@ class RequestTest extends TestCase {
         $this->assertFalse($request->hasHeader('content-length'));
     }
 
-    public function testSetBodyWrongType() {
+    public function testSetBodyWithConvertibleType() {
+        $client = $this->createMock(Client::class);
+        $request = new Request($client, 'POST', Http::createFromString('/'), [
+            'content-length' => '0',
+        ]);
+
+        $request->setBody(42);
+        $this->assertTrue(true);
+    }
+
+    public function testSetBodyWithWrongType() {
         $client = $this->createMock(Client::class);
         $request = new Request($client, 'POST', Http::createFromString('/'), [
             'content-length' => '0',
         ]);
 
         $this->expectException(\TypeError::class);
-        $request->setBody(42);
+        $request->setBody(new \stdClass);
     }
 
     public function testCookies() {

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -29,10 +29,16 @@ class ResponseTest extends TestCase {
         });
     }
 
+    public function testSetBodyWithConvertibleType() {
+        $response = new Response;
+        $response->setBody(42);
+        $this->assertTrue(true);
+    }
+
     public function testSetBodyWithWrongType() {
         $response = new Response;
         $this->expectException(\TypeError::class);
-        $response->setBody(42);
+        $response->setBody(new \stdClass);
     }
 
     public function testCookies() {

--- a/test/TrailersTest.php
+++ b/test/TrailersTest.php
@@ -59,6 +59,10 @@ class TrailersTest extends TestCase {
     }
 
     public function testSetHeadersIsAtomic() {
+        if (\ini_get('zend.assertions') !== '1' || !\ini_get('assert.exception')) {
+            $this->markTestSkipped('Assertions need to be enabled and throw for this test.');
+        }
+
         $trailers = new Trailers([]);
 
         try {


### PR DESCRIPTION
Two separate methods would really have been cleaner, as that would have allowed people to use strict types if they prefer.