### PR TITLE
Log error if zlib is disabled

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -115,7 +115,14 @@ final class Server {
         );
 
         if ($this->options->isCompressionEnabled()) {
-            $requestHandler = Middleware\stack($requestHandler, new CompressionMiddleware);
+            if (!\extension_loaded('zlib')) {
+                $this->logger->error(
+                    "The zlib extension is not loaded which prevents using compression. " .
+                    "Either activate the zlib extension or disable compression in the server's options."
+                );
+            } else {
+                $requestHandler = Middleware\stack($requestHandler, new CompressionMiddleware);
+            }
         }
 
         $this->requestHandler = $requestHandler;

--- a/src/Server.php
+++ b/src/Server.php
@@ -116,7 +116,7 @@ final class Server {
 
         if ($this->options->isCompressionEnabled()) {
             if (!\extension_loaded('zlib')) {
-                $this->logger->error(
+                $this->logger->warning(
                     "The zlib extension is not loaded which prevents using compression. " .
                     "Either activate the zlib extension or disable compression in the server's options."
                 );


### PR DESCRIPTION
Using compression defaults to true in Options which can lead to an `Undefined constant ZLIB_ENCODING_GZIP` error on a php built without zlib.

This check prevents the compression middleware to be added to the stack on these systems while advising user to install zlib.