### PR TITLE
Remove redundant check

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -113,7 +113,7 @@ final class Server
 
         $this->logger = $logger;
         $this->options = $options ?? new Options;
-        $this->clientFactory = $clientFactory ?? new DefaultClientFactory;
+        $this->clientFactory = new DefaultClientFactory;
         $this->timeReference = new SystemTimeReference;
         $this->timeouts = new TimeoutCache(
             $this->timeReference,


### PR DESCRIPTION
`$clientFactory` will never have a value. Perhaps it used to be a constructor argument, or this line was copied from elsewhere.