### PR TITLE
Refactor flood prevention

### DIFF
--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -31,7 +31,6 @@ final class Http2Driver implements HttpDriver
     public const DEFAULT_MAX_FRAME_SIZE = 1 << 14;
     public const DEFAULT_WINDOW_SIZE = (1 << 16) - 1;
 
-    private const SMALL_WINDOW_UPDATE_THRESHOLD = 1024;
     private const MINIMUM_WINDOW = (1 << 15) - 1;
     private const MAX_INCREMENT = (1 << 16) - 1;
 
@@ -626,7 +625,6 @@ final class Http2Driver implements HttpDriver
 
         $totalBytesReceivedSinceReset = 0;
         $payloadBytesReceivedSinceReset = 0;
-        $smallWindowUpdates = 0;
         $lastReset = $lastStreamOpening = $this->timeReference->getCurrentTime();
         $continuation = false;
 
@@ -1288,14 +1286,6 @@ final class Http2Driver implements HttpDriver
 
                             $windowSize = \unpack("N", $buffer)[1];
                             $buffer = \substr($buffer, 4);
-
-                            if ($windowSize < self::SMALL_WINDOW_UPDATE_THRESHOLD && ++$smallWindowUpdates > 10) {
-                                throw new Http2ConnectionException(
-                                    $this->client,
-                                    "Too many small window updates",
-                                    self::ENHANCE_YOUR_CALM
-                                );
-                            }
 
                             if ($id) {
                                 if (!isset($this->streams[$id])) {

--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -621,11 +621,9 @@ final class Http2Driver implements HttpDriver
     {
         $maxHeaderSize = $this->options->getHeaderSizeLimit();
         $maxBodySize = $this->options->getBodySizeLimit();
-        $maxFramesPerSecond = $this->options->getFramesPerSecondLimit();
-        $minAverageFrameSize = $this->options->getMinimumAverageFrameSize();
 
-        $frameCount = 0;
-        $bytesReceived = 0;
+        $totalBytesReceivedSinceReset = 0;
+        $payloadBytesReceivedSinceReset = 0;
         $lastReset = $this->timeReference->getCurrentTime();
         $continuation = false;
 
@@ -708,19 +706,21 @@ final class Http2Driver implements HttpDriver
             }
 
             while (true) {
-                if (++$frameCount === $maxFramesPerSecond) {
-                    $now = $this->timeReference->getCurrentTime();
-                    if ($lastReset === $now && $bytesReceived / $frameCount < $minAverageFrameSize) {
+                $now = $this->timeReference->getCurrentTime();
+                if ($lastReset === $now) {
+                    // Inspired by nginx flood detection:
+                    // https://github.com/nginx/nginx/commit/af0e284b967d0ecff1abcdce6558ed4635e3e757
+                    if ($totalBytesReceivedSinceReset > $payloadBytesReceivedSinceReset + 8192) {
                         throw new Http2ConnectionException(
                             $this->client,
-                            "Average frame size too low",
+                            "Flood detected",
                             self::ENHANCE_YOUR_CALM
                         );
                     }
-
+                } else {
                     $lastReset = $now;
-                    $frameCount = 0;
-                    $bytesReceived = 0;
+                    $totalBytesReceivedSinceReset = 0;
+                    $payloadBytesReceivedSinceReset = 0;
                 }
 
                 while (\strlen($buffer) < 9) {
@@ -728,7 +728,7 @@ final class Http2Driver implements HttpDriver
                 }
 
                 $length = \unpack("N", "\0" . \substr($buffer, 0, 3))[1];
-                $bytesReceived += $length;
+                $totalBytesReceivedSinceReset += $length + 9;
 
                 if ($length > self::DEFAULT_MAX_FRAME_SIZE) { // Do we want to allow increasing max frame size?
                     throw new Http2ConnectionException($this->client, "Max frame size exceeded", self::FRAME_SIZE_ERROR);
@@ -808,6 +808,8 @@ final class Http2Driver implements HttpDriver
                                     self::PROTOCOL_ERROR
                                 );
                             }
+
+                            $payloadBytesReceivedSinceReset += $length;
 
                             $this->serverWindow -= $length;
                             $stream->serverWindow -= $length;
@@ -985,6 +987,8 @@ final class Http2Driver implements HttpDriver
                                     self::ENHANCE_YOUR_CALM
                                 );
                             }
+
+                            $payloadBytesReceivedSinceReset += $length;
 
                             while (\strlen($buffer) < $length) {
                                 $buffer .= yield;
@@ -1344,6 +1348,8 @@ final class Http2Driver implements HttpDriver
                                 );
                             }
 
+                            $payloadBytesReceivedSinceReset += $length;
+
                             while (\strlen($buffer) < $length) {
                                 $buffer .= yield;
                             }
@@ -1635,6 +1641,7 @@ final class Http2Driver implements HttpDriver
             }
         } catch (Http2ConnectionException $exception) {
             $this->shutdown(null, $exception);
+            $this->client->close();
         }
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -10,8 +10,7 @@ final class Options
     private $connectionTimeout = 15; // seconds
 
     private $concurrentStreamLimit = 256;
-    private $framesPerSecondLimit = 1024;
-    private $minimumAverageFrameSize = 1024;
+
     private $allowedMethods = ["GET", "POST", "PUT", "PATCH", "HEAD", "OPTIONS", "DELETE"];
 
     private $bodySizeLimit = 131072;
@@ -153,7 +152,7 @@ final class Options
 
     /**
      * @param int $bytes Default maximum request body size in bytes. Individual requests may be increased by calling
-     *     `RequestBody::increaseSizeLimit($newLimit)`. Default is 131072 (128k).
+     *                   `RequestBody::increaseSizeLimit($newLimit)`. Default is 131072 (128k).
      *
      * @return self
      *
@@ -211,7 +210,7 @@ final class Options
     }
 
     /**
-     * @param int $streams Maximum number of concurrent HTTP/2 streams. Default is 20.
+     * @param int $streams Maximum number of concurrent HTTP/2 streams. Default is 256.
      *
      * @return self
      *
@@ -232,67 +231,6 @@ final class Options
     }
 
     /**
-     * @return int Minimum average frame size required if more than the maximum number of frames per second are
-     *     received on an HTTP/2 connection.
-     */
-    public function getMinimumAverageFrameSize(): int
-    {
-        return $this->minimumAverageFrameSize;
-    }
-
-    /**
-     * @param int $size Minimum average frame size required if more than the maximum number of frames per second are
-     *     received on an HTTP/2 connection. Default is 1024 (1k).
-     *
-     * @return self
-     *
-     * @throws \Error If the size is less than 1.
-     */
-    public function withMinimumAverageFrameSize(int $size): self
-    {
-        if ($size < 1) {
-            throw new \Error(
-                "Minimum average frame size must be greater than zero"
-            );
-        }
-
-        $new = clone $this;
-        $new->minimumAverageFrameSize = $size;
-
-        return $new;
-    }
-
-    /**
-     * @return int Maximum number of HTTP/2 frames per second before the average length minimum is enforced.
-     */
-    public function getFramesPerSecondLimit(): int
-    {
-        return $this->framesPerSecondLimit;
-    }
-
-    /**
-     * @param int $frames Maximum number of HTTP/2 frames per second before the average length minimum is enforced.
-     *     Default is 60.
-     *
-     * @return self
-     *
-     * @throws \Error If the frame count is less than 1.
-     */
-    public function withFramesPerSecondLimit(int $frames): self
-    {
-        if ($frames < 1) {
-            throw new \Error(
-                "Max number of HTTP/2 frames per second setting must be greater than zero"
-            );
-        }
-
-        $new = clone $this;
-        $new->framesPerSecondLimit = $frames;
-
-        return $new;
-    }
-
-    /**
      * @return int The maximum number of bytes to read from a client per read.
      */
     public function getChunkSize(): int
@@ -302,7 +240,7 @@ final class Options
 
     /**
      * @param int $bytes The maximum number of bytes to read from a client per read. Larger numbers are better for
-     *     performance but can increase memory usage. Default is 8192 (8k).
+     *                   performance but can increase memory usage. Default is 8192 (8k).
      *
      * @return self
      *
@@ -332,7 +270,7 @@ final class Options
 
     /**
      * @param int $bytes TThe minimum number of bytes to write to a client time for streamed responses. Larger numbers
-     *     are better for performance but can increase memory usage. Default is 1024 (1k).
+     *                   are better for performance but can increase memory usage. Default is 1024 (1k).
      *
      * @return self
      *
@@ -362,7 +300,7 @@ final class Options
 
     /**
      * @param string[] $allowedMethods An array of allowed request methods. Default is GET, POST, PUT, PATCH, HEAD,
-     *     OPTIONS, DELETE.
+     *                                 OPTIONS, DELETE.
      *
      * @return self
      *

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -642,7 +642,7 @@ class Http2DriverTest extends HttpDriverTest
         $driver = new Http2Driver(new Options, $this->createMock(TimeReference::class), new NullLogger);
 
         $client = $this->createClientMock();
-        $client->expects($this->once())
+        $client->expects($this->atLeastOnce())
             ->method('close');
 
         $lastWrite = null;
@@ -677,7 +677,7 @@ class Http2DriverTest extends HttpDriverTest
         $driver = new Http2Driver(new Options, $this->createMock(TimeReference::class), new NullLogger);
 
         $client = $this->createClientMock();
-        $client->expects($this->once())
+        $client->expects($this->atLeastOnce())
             ->method('close');
 
         $lastWrite = null;

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -636,4 +636,83 @@ class Http2DriverTest extends HttpDriverTest
         $request = $requests[\count($requests) - 1];
         $this->assertSame("key=value", $request->getUri()->getQuery());
     }
+
+    public function testPingFlood(): void
+    {
+        $driver = new Http2Driver(new Options, $this->createMock(TimeReference::class), new NullLogger);
+
+        $client = $this->createClientMock();
+        $client->expects($this->once())
+            ->method('close');
+
+        $lastWrite = null;
+
+        $parser = $driver->setup(
+            $client,
+            $this->createCallback(0),
+            function (string $data) use (&$lastWrite) {
+                $lastWrite = $data;
+                return new Success;
+            }
+        );
+
+        $parser->send(Http2Driver::PREFACE);
+
+        $buffer = "";
+        $ping = "aaaaaaaa";
+        for ($i = 0; $i < 1024; ++$i) {
+            $buffer .= self::packFrame($ping++, Http2Driver::PING, Http2Driver::NOFLAG);
+        }
+
+        $parser->send($buffer);
+
+        $this->assertSame(
+            self::packFrame(\pack("NN", 0, Http2Driver::ENHANCE_YOUR_CALM), Http2Driver::GOAWAY, Http2Driver::NOFLAG),
+            $lastWrite
+        );
+    }
+
+    public function testTinyDataFlood(): void
+    {
+        $driver = new Http2Driver(new Options, $this->createMock(TimeReference::class), new NullLogger);
+
+        $client = $this->createClientMock();
+        $client->expects($this->once())
+            ->method('close');
+
+        $lastWrite = null;
+
+        $parser = $driver->setup(
+            $client,
+            $this->createCallback(1),
+            function (string $data) use (&$lastWrite) {
+                $lastWrite = $data;
+                return new Success;
+            }
+        );
+
+        $parser->send(Http2Driver::PREFACE);
+
+        $headers = [
+            ":authority" => "localhost",
+            ":path" => "/base",
+            ":scheme" => "https",
+            ":method" => "POST",
+            "content-length" => "1024"
+        ];
+        $parser->send(self::packHeader($headers, false, 1));
+
+        $buffer = "";
+        for ($i = 0; $i < 1023; ++$i) {
+            $buffer .= self::packFrame(" ", Http2Driver::DATA, Http2Driver::NOFLAG, 1);
+        }
+        $buffer .= self::packFrame(" ", Http2Driver::DATA, Http2Driver::END_STREAM, 1);
+
+        $parser->send($buffer);
+
+        $this->assertSame(
+            self::packFrame(\pack("NN", 0, Http2Driver::ENHANCE_YOUR_CALM), Http2Driver::GOAWAY, Http2Driver::NOFLAG),
+            $lastWrite
+        );
+    }
 }

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -143,42 +143,6 @@ class OptionsTest extends TestCase
         $options->withConcurrentStreamLimit(0);
     }
 
-    public function testWithMinimumAverageFrameSize(): void
-    {
-        $options = new Options;
-
-        // default
-        $this->assertSame(1024, $options->getMinimumAverageFrameSize());
-
-        // change
-        $this->assertSame(1, $options->withMinimumAverageFrameSize(1)->getMinimumAverageFrameSize());
-
-        // change doesn't affect original
-        $this->assertSame(1024, $options->getMinimumAverageFrameSize());
-
-        // invalid
-        $this->expectException(\Error::class);
-        $options->withMinimumAverageFrameSize(0);
-    }
-
-    public function testWithFramesPerSecondLimit(): void
-    {
-        $options = new Options;
-
-        // default
-        $this->assertSame(1024, $options->getFramesPerSecondLimit());
-
-        // change
-        $this->assertSame(1, $options->withFramesPerSecondLimit(1)->getFramesPerSecondLimit());
-
-        // change doesn't affect original
-        $this->assertSame(1024, $options->getFramesPerSecondLimit());
-
-        // invalid
-        $this->expectException(\Error::class);
-        $options->withFramesPerSecondLimit(0);
-    }
-
     public function testWithChunkSize(): void
     {
         $options = new Options;


### PR DESCRIPTION
Dropping arbitrary average frame size in favor of nginx-inspired flood protection based on the number of payload (header or data) frames received vs. the overall number of bytes received, including frame headers. This protects against both control frame floods and tiny data frame floods.