### PR TITLE
Make flood detection less strict

### DIFF
--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -713,7 +713,7 @@ final class Http2Driver implements HttpDriver
                 if ($lastReset === $now) {
                     // Inspired by nginx flood detection:
                     // https://github.com/nginx/nginx/commit/af0e284b967d0ecff1abcdce6558ed4635e3e757
-                    if ($totalBytesReceivedSinceReset > $payloadBytesReceivedSinceReset + 8192) {
+                    if ($totalBytesReceivedSinceReset / 2 > $payloadBytesReceivedSinceReset + 8192) {
                         throw new Http2ConnectionException(
                             $this->client,
                             "Flood detected",


### PR DESCRIPTION
Otherwise [`benchmark.php`](https://github.com/amphp/http-client/blob/69013f4efc3a66607e7a26a72b1062fe932a86da/examples/concurrency/3-benchmark.php) triggers this condition with just sending GET requests, which isn't the situation that flood detection should prevent. The example needs to be modified to use `https://localhost:1338/` and be called with `0` as process argument.