### PR TITLE
Fix bug related to HTTP content chunking

### DIFF
--- a/src/Driver/Http1Driver.php
+++ b/src/Driver/Http1Driver.php
@@ -660,15 +660,13 @@ final class Http1Driver implements HttpDriver
                             if ($bufferLength >= $chunkLengthRemaining + 2) {
                                 $buffer .= yield $emitter->emit(\substr($buffer, 0, $chunkLengthRemaining));
                                 $buffer = \substr($buffer, $chunkLengthRemaining + 2);
-                            } else {
-                                $buffer = yield $emitter->emit($buffer);
-                                $chunkLengthRemaining -= $bufferLength;
-                            }
 
-                            if ($bufferLength >= $chunkLengthRemaining + 2) {
                                 $chunkLengthRemaining = null;
                                 continue 2; // next chunk (chunked loop)
                             }
+
+                            $buffer = yield $emitter->emit($buffer);
+                            $chunkLengthRemaining -= $bufferLength;
                         }
                     }
 


### PR DESCRIPTION
The current implementation of chunk parsing can break in specific combinations of HTTP chunk-size and options::$chunkSize.

I added a test-data provider which runs the chunk test with chunk-sizes from 1 to 10 against the example HTTP request with chunks in size 4 and 5. This breaks without the fix to `Http1Driver`.

I also had to edit `composer.json` to make sure PHPUnit does not upgrade to v8 as this is incompatible with the listener configuration in `phpunit.xml.dist`. I considered it out of the scope of this MR to fix the deprecated listener config.