### PR TITLE
Improve exception logging

### DIFF
--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -610,7 +610,7 @@ final class RemoteClient implements Client
             return;
         } catch (\Throwable $exception) {
             $errorType = \get_class($exception);
-            $this->logger->critical(
+            $this->logger->error(
                 "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error handler.",
                 ['exception' => $exception]
             );
@@ -668,7 +668,7 @@ final class RemoteClient implements Client
         } catch (\Throwable $exception) {
             // If the error handler throws, fallback to returning the default error page.
             $errorType = \get_class($exception);
-            $this->logger->critical(
+            $this->logger->error(
                 "Unexpected {$errorType} thrown from ErrorHandler::handleError(), falling back to default error handler.",
                 ['exception' => $exception]
             );
@@ -705,7 +705,7 @@ final class RemoteClient implements Client
             }
 
             $errorType = \get_class($exception);
-            $this->logger->critical(
+            $this->logger->error(
                 "Unexpected {$errorType} thrown during socket upgrade, closing connection.",
                 ['exception' => $exception]
             );

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -605,7 +605,7 @@ final class RemoteClient implements Client
             $this->close();
             return;
         } catch (\Throwable $exception) {
-            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+            $this->logger->error('An exception was thrown while processing a request.', ['exception' => $exception]);
             $response = yield from $this->makeExceptionResponse($request);
         } finally {
             $this->pendingHandlers--;

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -691,7 +691,7 @@ final class RemoteClient implements Client
                 return;
             }
 
-            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+            $this->logger->error('Unexpected exception during socket upgrade, closing connection.', ['exception' => $exception]);
             $this->close();
         });
     }

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -658,7 +658,7 @@ final class RemoteClient implements Client
             return yield $this->errorHandler->handleError($status, null, $request);
         } catch (\Throwable $exception) {
             // If the error handler throws, fallback to returning the default HTML error page.
-            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+            $this->logger->error('Error handler threw an exception, falling back to the default HTML error page.', ['exception' => $exception]);
 
             // The default error handler will never throw, otherwise there's a bug
             return yield self::$defaultErrorHandler->handleError($status, null, $request);

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -396,7 +396,7 @@ final class RemoteClient implements Client
             }
         } catch (\Throwable $exception) {
             // Parser *should not* throw an exception, but in case it does...
-            $this->logger->critical($exception);
+            $this->logger->critical($exception->getMessage(), ['exception' => $exception]);
             $this->close();
         }
     }
@@ -605,7 +605,7 @@ final class RemoteClient implements Client
             $this->close();
             return;
         } catch (\Throwable $exception) {
-            $this->logger->error($exception);
+            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
             $response = yield from $this->makeExceptionResponse($request);
         } finally {
             $this->pendingHandlers--;
@@ -658,7 +658,7 @@ final class RemoteClient implements Client
             return yield $this->errorHandler->handleError($status, null, $request);
         } catch (\Throwable $exception) {
             // If the error handler throws, fallback to returning the default HTML error page.
-            $this->logger->error($exception);
+            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
 
             // The default error handler will never throw, otherwise there's a bug
             return yield self::$defaultErrorHandler->handleError($status, null, $request);
@@ -691,7 +691,7 @@ final class RemoteClient implements Client
                 return;
             }
 
-            $this->logger->error($exception);
+            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
             $this->close();
         });
     }

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -614,7 +614,7 @@ final class RemoteClient implements Client
                 "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error handler.",
                 ['exception' => $exception]
             );
-            
+
             $response = yield from $this->makeExceptionResponse($request);
         } finally {
             $this->pendingHandlers--;

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -396,7 +396,11 @@ final class RemoteClient implements Client
             }
         } catch (\Throwable $exception) {
             // Parser *should not* throw an exception, but in case it does...
-            $this->logger->critical('Request parser threw an exception (this should never happen).', ['exception' => $exception]);
+            $errorType = \get_class($exception);
+            $this->logger->critical("Unexpected {$errorType} while parsing request, closing connection.", [
+                'exception' => $exception
+            ]);
+
             $this->close();
         }
     }
@@ -605,7 +609,12 @@ final class RemoteClient implements Client
             $this->close();
             return;
         } catch (\Throwable $exception) {
-            $this->logger->error('An exception was thrown while processing a request.', ['exception' => $exception]);
+            $errorType = \get_class($exception);
+            $this->logger->critical(
+                "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error response.",
+                ['exception' => $exception]
+            );
+            
             $response = yield from $this->makeExceptionResponse($request);
         } finally {
             $this->pendingHandlers--;
@@ -657,8 +666,12 @@ final class RemoteClient implements Client
         try {
             return yield $this->errorHandler->handleError($status, null, $request);
         } catch (\Throwable $exception) {
-            // If the error handler throws, fallback to returning the default HTML error page.
-            $this->logger->error('Error handler threw an exception, falling back to the default HTML error page.', ['exception' => $exception]);
+            // If the error handler throws, fallback to returning the default error page.
+            $errorType = \get_class($exception);
+            $this->logger->critical(
+                "Unexpected {$errorType} thrown from ErrorHandler::handleError(), falling back to default error handler.",
+                ['exception' => $exception]
+            );
 
             // The default error handler will never throw, otherwise there's a bug
             return yield self::$defaultErrorHandler->handleError($status, null, $request);
@@ -691,7 +704,12 @@ final class RemoteClient implements Client
                 return;
             }
 
-            $this->logger->error('Unexpected exception during socket upgrade, closing connection.', ['exception' => $exception]);
+            $errorType = \get_class($exception);
+            $this->logger->critical(
+                "Unexpected {$errorType} thrown during socket upgrade, closing connection.",
+                ['exception' => $exception]
+            );
+
             $this->close();
         });
     }

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -397,9 +397,10 @@ final class RemoteClient implements Client
         } catch (\Throwable $exception) {
             // Parser *should not* throw an exception, but in case it does...
             $errorType = \get_class($exception);
-            $this->logger->critical("Unexpected {$errorType} while parsing request, closing connection.", [
-                'exception' => $exception
-            ]);
+            $this->logger->critical(
+                "Unexpected {$errorType} while parsing request, closing connection.",
+                ['exception' => $exception]
+            );
 
             $this->close();
         }

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -611,7 +611,7 @@ final class RemoteClient implements Client
         } catch (\Throwable $exception) {
             $errorType = \get_class($exception);
             $this->logger->critical(
-                "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error response.",
+                "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error handler.",
                 ['exception' => $exception]
             );
             

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -396,7 +396,7 @@ final class RemoteClient implements Client
             }
         } catch (\Throwable $exception) {
             // Parser *should not* throw an exception, but in case it does...
-            $this->logger->critical($exception->getMessage(), ['exception' => $exception]);
+            $this->logger->critical('Request parser threw an exception (this should never happen).', ['exception' => $exception]);
             $this->close();
         }
     }

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -41,7 +41,7 @@ final class ExceptionMiddleware implements Middleware, ServerObserver
             } catch (\Throwable $exception) {
                 $status = Status::INTERNAL_SERVER_ERROR;
 
-                $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+                $this->logger->error('An exception was thrown while processing a request, causing an error 500 response.', ['exception' => $exception]);
 
                 // Return an HTML page with the exception in debug mode.
                 if ($this->debug) {

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -41,10 +41,15 @@ final class ExceptionMiddleware implements Middleware, ServerObserver
             } catch (\Throwable $exception) {
                 $status = Status::INTERNAL_SERVER_ERROR;
 
-                $this->logger->error('An exception was thrown while processing a request, causing an error 500 response.', ['exception' => $exception]);
+                $errorType = \get_class($exception);
 
                 // Return an HTML page with the exception in debug mode.
                 if ($this->debug) {
+                    $this->logger->error(
+                        "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to stack trace response, because debug mode is enabled.",
+                        ['exception' => $exception]
+                    );
+
                     $html = \str_replace(
                         ["{uri}", "{class}", "{message}", "{file}", "{line}", "{trace}"],
                         \array_map("htmlspecialchars", [
@@ -62,6 +67,11 @@ final class ExceptionMiddleware implements Middleware, ServerObserver
                         "content-type" => "text/html; charset=utf-8",
                     ], $html);
                 }
+
+                $this->logger->error(
+                    "Unexpected {$errorType} thrown from RequestHandler::handleRequest(), falling back to error handler.",
+                    ['exception' => $exception]
+                );
 
                 return yield $this->errorHandler->handleError($status, null, $request);
             }

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -41,7 +41,7 @@ final class ExceptionMiddleware implements Middleware, ServerObserver
             } catch (\Throwable $exception) {
                 $status = Status::INTERNAL_SERVER_ERROR;
 
-                $this->logger->error($exception);
+                $this->logger->error($exception->getMessage(), ['exception' => $exception]);
 
                 // Return an HTML page with the exception in debug mode.
                 if ($this->debug) {


### PR DESCRIPTION
I had a problem that my monolog handlers were not logging exceptions correctly. It is because they expect the exception to be in the context.