### PR TITLE
Implemented listenAndServe, handleFunc and html functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,36 +40,21 @@ composer require amphp/http-server
 ```php
 <?php
 
-use Amp\Http\Server\RequestHandler\CallableRequestHandler;
-use Amp\Http\Server\HttpServer;
 use Amp\Http\Server\Request;
 use Amp\Http\Server\Response;
-use Amp\Http\Status;
-use Amp\Socket\Server;
-use Psr\Log\NullLogger;
+use function Amp\Http\Server\handleFunc;
+use function Amp\Http\Server\html;
+use function Amp\Http\Server\listenAndServe;
 
-// Run this script, then visit http://localhost:1337/ in your browser.
+// Run this script, then visit http://localhost:8000/ in your browser.
 
-Amp\Loop::run(function () {
-    $sockets = [
-        Server::listen("0.0.0.0:1337"),
-        Server::listen("[::]:1337"),
-    ];
+function helloWorld(Request $request): Response
+{
+    return html('Hello World!');
+}
 
-    $server = new HttpServer($sockets, new CallableRequestHandler(function (Request $request) {
-        return new Response(Status::OK, [
-            "content-type" => "text/plain; charset=utf-8"
-        ], "Hello, World!");
-    }), new NullLogger);
-
-    yield $server->start();
-
-    // Stop the server gracefully when SIGINT is received.
-    // This is technically optional, but it is best to call Server::stop().
-    Amp\Loop::onSignal(SIGINT, function (string $watcherId) use ($server) {
-        Amp\Loop::cancel($watcherId);
-        yield $server->stop();
-    });
+Amp\Loop::run(static function () {
+    yield listenAndServe('0.0.0.0:8000', handleFunc('helloWorld'));
 });
 ```
 

--- a/examples/hello-world-simple.php
+++ b/examples/hello-world-simple.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+require \dirname(__DIR__) . "/vendor/autoload.php";
+
+use Amp\Http\Server\Request;
+use Amp\Http\Server\Response;
+use function Amp\Http\Server\handleFunc;
+use function Amp\Http\Server\html;
+use function Amp\Http\Server\listenAndServe;
+
+function helloWorld(Request $request): Response
+{
+    return html('Hello World!');
+}
+
+Amp\Loop::run(static function () {
+    yield listenAndServe('0.0.0.0:8000', handleFunc('helloWorld'));
+});

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,9 +2,65 @@
 
 namespace Amp\Http\Server;
 
+use Amp\ByteStream\InputStream;
 use Amp\Http\Status;
+use Amp\Promise;
+use Amp\Socket\Server as Socket;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use function Amp\call;
 
 function redirectTo(string $uri, int $statusCode = Status::FOUND): Response
 {
     return new Response($statusCode, ['location' => $uri]);
+}
+
+/**
+ * Returns a response with the html content type.
+ *
+ * @param InputStream|string|null $content
+ */
+function html($content, int $status = Status::OK): Response
+{
+    return new Response($status, [
+        'Content-Type' => 'text/html; charset=utf-8'
+    ], $content);
+}
+
+/**
+ * Creates an HTTP server.
+ *
+ * This function is inspired in Golang's http module one. It provides sensible defaults for a really quick start
+ * and it is designed to cover 90% of use cases.
+ *
+ * If you need fine-tuning, like listening in two sockets or attach more listeners to the server
+ * you should bootstrap your server manually.
+ *
+ * @return Promise<HttpServer>
+ */
+function listenAndServe(string $address, RequestHandler $handler, ?Options $options, ?LoggerInterface $logger): Promise
+{
+    return call(static function () use ($address, $handler, $options, $logger) {
+        $sockets = [
+            Socket::listen($address)
+        ];
+
+        $logger = $logger ?? new NullLogger();
+
+        $server = new HttpServer($sockets, $handler, $logger, $options);
+
+        yield $server->start();
+
+        return $server;
+    });
+}
+
+/**
+ * Wraps a php callable in an amp http server handler.
+ *
+ * @param callable(Request): Promise<Response> $callable
+ */
+function handleFunc(callable $callable): RequestHandler
+{
+    return new RequestHandler\CallableRequestHandler($callable);
 }


### PR DESCRIPTION
Added a couple of functions inspired in golang's http package.

`listenAndServe` makes really quick and straightforward to boot up a server passing a handler and a socket address.

`handleFunc` is a convenience function to transform a callable into a handler. It is less verbose that constructing the adapter.

`html` is just a wrapper for creating an html response.

Overall, these functions make the quickstart process easier, more elegant, more readable, and a bit more "golangish". 😛 

I modified the readme showcasing the simplified approach:

```php
<?php

use Amp\Http\Server\Request;
use Amp\Promise;
use Amp\Success;
use function Amp\Http\Server\handleFunc;
use function Amp\Http\Server\html;
use function Amp\Http\Server\listenAndServe;

// Run this script, then visit http://localhost:8000/ in your browser.

function helloWorld(Request $request): Promise {
    return new Success(html('Hello World!'));
}

Amp\Loop::run(static function () {
    yield from listenAndServe('0.0.0.0:8000', handleFunc('helloWorld'));
});

```