### PR TITLE
Load `src/Server.php` as file-autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         },
         "files": [
             "src/Middleware/functions.php",
-            "src/functions.php"
+            "src/functions.php",
+            "src/Server.php"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
The file only contains a `class_alias` to `HttpServer` which is not picked up in `--classmap-authoritative` composer-autoloaders. Adding it to the autoload-files list fixes this. 

Fixes #319 