### PR TITLE
Fixes on v3

### DIFF
--- a/examples/delayed-response.php
+++ b/examples/delayed-response.php
@@ -19,8 +19,8 @@ use function Amp\trapSignal;
 // Run this script, then visit http://localhost:1337/ in your browser.
 
 $servers = [
-    Socket\Server::listen("0.0.0.0:1337"),
-    Socket\Server::listen("[::]:1337"),
+    Socket\listen("0.0.0.0:1337"),
+    Socket\listen("[::]:1337"),
 ];
 
 $logHandler = new StreamHandler(ByteStream\getStdout());

--- a/examples/exception.php
+++ b/examples/exception.php
@@ -15,8 +15,8 @@ use function Amp\trapSignal;
 // Run this script, then visit http://localhost:1337/ in your browser.
 
 $servers = [
-    Socket\Server::listen("0.0.0.0:1337"),
-    Socket\Server::listen("[::]:1337"),
+    Socket\listen("0.0.0.0:1337"),
+    Socket\listen("[::]:1337"),
 ];
 
 $logHandler = new StreamHandler(ByteStream\getStdout());

--- a/examples/hello-world.php
+++ b/examples/hello-world.php
@@ -23,10 +23,10 @@ $context = (new Socket\BindContext)
         ->withTlsContext((new Socket\ServerTlsContext)->withDefaultCertificate($cert));
 
 $servers = [
-        Socket\Server::listen("0.0.0.0:1337"),
-        Socket\Server::listen("[::]:1337"),
-        Socket\Server::listen("0.0.0.0:1338", $context),
-        Socket\Server::listen("[::]:1338", $context),
+        Socket\listen("0.0.0.0:1337"),
+        Socket\listen("[::]:1337"),
+        Socket\listen("0.0.0.0:1338", $context),
+        Socket\listen("[::]:1338", $context),
 ];
 
 $logHandler = new StreamHandler(ByteStream\getStdout());

--- a/examples/state.php
+++ b/examples/state.php
@@ -18,8 +18,8 @@ use function Amp\trapSignal;
 // Run this script, then visit http://localhost:1337/ in your browser.
 
 $servers = [
-    Socket\Server::listen("0.0.0.0:1337"),
-    Socket\Server::listen("[::]:1337"),
+    Socket\listen("0.0.0.0:1337"),
+    Socket\listen("[::]:1337"),
 ];
 
 $logHandler = new StreamHandler(ByteStream\getStdout());

--- a/examples/stream.php
+++ b/examples/stream.php
@@ -3,9 +3,8 @@
 
 require \dirname(__DIR__) . "/vendor/autoload.php";
 
-use Amp\Pipeline\AsyncGenerator;
 use Amp\ByteStream;
-use Amp\ByteStream\PipelineStream;
+use Amp\ByteStream\IterableStream;
 use Amp\Http\Server\HttpServer;
 use Amp\Http\Server\Options;
 use Amp\Http\Server\Request;
@@ -22,8 +21,8 @@ use function Amp\trapSignal;
 // Run this script, then visit http://localhost:1337/ in your browser.
 
 $servers = [
-    Socket\Server::listen("0.0.0.0:1337"),
-    Socket\Server::listen("[::]:1337"),
+    Socket\listen("0.0.0.0:1337"),
+    Socket\listen("[::]:1337"),
 ];
 
 $logHandler = new StreamHandler(ByteStream\getStdout());
@@ -35,12 +34,12 @@ $server = new HttpServer($servers, new CallableRequestHandler(function (Request 
     // We stream the response here, one line every 100 ms.
     return new Response(Status::OK, [
         "content-type" => "text/plain; charset=utf-8",
-    ], new PipelineStream(new AsyncGenerator(function () {
+    ], new IterableStream((function () {
         for ($i = 0; $i < 30; $i++) {
             delay(0.1);
             yield "Line {$i}\r\n";
         }
-    })));
+    })()));
 }), $logger, (new Options)->withoutCompression());
 
 $server->start();

--- a/src/Driver/Http1Driver.php
+++ b/src/Driver/Http1Driver.php
@@ -2,7 +2,8 @@
 
 namespace Amp\Http\Server\Driver;
 
-use Amp\ByteStream\PipelineStream;
+use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableResourceStream;
 use Amp\DeferredFuture;
 use Amp\Future;
 use Amp\Http\InvalidHeaderException;
@@ -509,7 +510,7 @@ final class Http1Driver implements HttpDriver
                 $maxBodySize = $this->options->getBodySizeLimit();
 
                 $body = new RequestBody(
-                    new PipelineStream($this->bodyEmitter->asPipeline()),
+                    new IterableStream($emitter->pipe()),
                     function (int $bodySize) use (&$maxBodySize) {
                         if ($bodySize > $maxBodySize) {
                             $maxBodySize = $bodySize;

--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -2,7 +2,8 @@
 
 namespace Amp\Http\Server\Driver;
 
-use Amp\ByteStream\PipelineStream;
+use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableResourceStream;
 use Amp\DeferredFuture;
 use Amp\Future;
 use Amp\Http\HPack;
@@ -904,7 +905,7 @@ final class Http2Driver implements HttpDriver, Http2Processor
         $this->bodyEmitters[$streamId] = new Emitter;
 
         $body = new RequestBody(
-            new PipelineStream($this->bodyEmitters[$streamId]->asPipeline()),
+            new IterableStream($this->bodyEmitters[$streamId]->pipe()),
             function (int $bodySize) use ($streamId) {
                 if (!isset($this->streams[$streamId], $this->bodyEmitters[$streamId])) {
                     return;

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -313,10 +313,12 @@ final class RemoteClient implements Client
 
         if ($close) {
             $this->status |= self::CLOSED_WR;
-            return $this->socket->end($data);
+            $this->socket->end($data);
+            return Future::complete();
         }
 
-        return $this->socket->write($data);
+        $this->socket->write($data);
+        return Future::complete();
     }
 
     /**

--- a/src/Driver/RemoteClient.php
+++ b/src/Driver/RemoteClient.php
@@ -313,7 +313,8 @@ final class RemoteClient implements Client
 
         if ($close) {
             $this->status |= self::CLOSED_WR;
-            $this->socket->end($data);
+            $this->socket->write($data);
+            $this->socket->end();
             return Future::complete();
         }
 

--- a/src/Driver/UpgradedSocket.php
+++ b/src/Driver/UpgradedSocket.php
@@ -3,7 +3,6 @@
 namespace Amp\Http\Server\Driver;
 
 use Amp\Cancellation;
-use Amp\Future;
 use Amp\Socket\EncryptableSocket;
 use Amp\Socket\Socket;
 use Amp\Socket\SocketAddress;
@@ -26,15 +25,19 @@ final class UpgradedSocket implements EncryptableSocket
         $this->buffer = $buffer !== '' ? $buffer : null;
     }
 
-    public function read(?Cancellation $token = null): ?string
+    public function read(?Cancellation $token = null, ?int $limit = null): ?string
     {
         if ($this->buffer !== null) {
             $buffer = $this->buffer;
             $this->buffer = null;
+            if($limit !== null && strlen($buffer) > $limit) {
+                $this->buffer = substr($buffer, $limit);
+                return substr($buffer, 0, $limit);
+            }
             return $buffer;
         }
 
-        return $this->socket->read($token);
+        return $this->socket->read($token, $limit);
     }
 
     public function close(): void
@@ -48,14 +51,14 @@ final class UpgradedSocket implements EncryptableSocket
         $this->close();
     }
 
-    public function write(string $data): Future
+    public function write(string $data): void
     {
-        return $this->socket->write($data);
+        $this->socket->write($data);
     }
 
-    public function end(string $finalData = ""): Future
+    public function end(string $finalData = ""): void
     {
-        return $this->socket->end($finalData);
+        $this->socket->end($finalData);
     }
 
     public function reference(): void

--- a/src/Driver/UpgradedSocket.php
+++ b/src/Driver/UpgradedSocket.php
@@ -56,9 +56,9 @@ final class UpgradedSocket implements EncryptableSocket
         $this->socket->write($data);
     }
 
-    public function end(string $finalData = ""): void
+    public function end(): void
     {
-        $this->socket->end($finalData);
+        $this->socket->end();
     }
 
     public function reference(): void

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -13,7 +13,7 @@ use Amp\Http\Server\Driver\TimeoutCache;
 use Amp\Http\Server\Middleware\CompressionMiddleware;
 use Amp\Socket;
 use Amp\Socket\ResourceSocket;
-use Amp\Socket\Server as SocketServer;
+use Amp\Socket\SocketServer;
 use Psr\Log\LoggerInterface as PsrLogger;
 use Revolt\EventLoop;
 use function Amp\async;
@@ -267,6 +267,7 @@ final class HttpServer
             try {
                 $this->stop(self::DEFAULT_SHUTDOWN_TIMEOUT);
             } finally {
+                var_dump($exceptions);
                 throw new CompositeException($exceptions, "onStart observer initialization failure");
             }
         }

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -267,7 +267,6 @@ final class HttpServer
             try {
                 $this->stop(self::DEFAULT_SHUTDOWN_TIMEOUT);
             } finally {
-                var_dump($exceptions);
                 throw new CompositeException($exceptions, "onStart observer initialization failure");
             }
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Server;
 
-use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Message;
@@ -204,7 +204,7 @@ final class Request extends Message
     public function getBody(): RequestBody
     {
         if ($this->body === null) {
-            $this->body = new RequestBody(new InMemoryStream);
+            $this->body = new RequestBody(new ReadableBuffer());
         }
 
         return $this->body;
@@ -227,7 +227,7 @@ final class Request extends Message
             return;
         }
 
-        $this->body = new RequestBody(new InMemoryStream($body));
+        $this->body = new RequestBody(new ReadableBuffer($body));
 
         if ($length = \strlen($body)) {
             $this->setHeader("content-length", (string) $length);

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Server;
 
-use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
 use Amp\Http\Cookie\ResponseCookie;
 use Amp\Http\Message;
@@ -95,7 +95,7 @@ final class Response extends Message
             return;
         }
 
-        $this->body = new InMemoryStream($stringOrStream);
+        $this->body = new ReadableBuffer($stringOrStream);
         $this->setHeader("content-length", (string) \strlen($stringOrStream));
     }
 

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Server\Test\Driver;
 
-use Amp\ByteStream\PipelineStream;
+use Amp\ByteStream\IterableStream;
 use Amp\Future;
 use Amp\Http\HPack;
 use Amp\Http\Http2\Http2Parser;
@@ -296,7 +296,7 @@ class Http2DriverTest extends HttpDriverTest
         $emitter = new Emitter;
         EventLoop::queue(fn () => $driver->write($request, new Response(Status::OK, [
             "content-length" => \strlen($body),
-        ], new PipelineStream($emitter->asPipeline()), $trailers)));
+        ], new IterableStream($emitter->pipe()), $trailers)));
 
         $emitter->emit($body);
         $emitter->complete();
@@ -357,7 +357,7 @@ class Http2DriverTest extends HttpDriverTest
         $request = new Request($this->createClientMock(), "GET", Uri\Http::createFromString('/'), [], '', '2');
 
         $emitter = new Emitter;
-        EventLoop::queue(fn () => $driver->write($request, new Response(Status::OK, [], new PipelineStream($emitter->asPipeline()))));
+        EventLoop::queue(fn () => $driver->write($request, new Response(Status::OK, [], new IterableStream($emitter->pipe()))));
 
         $emitter->emit("foo");
         $emitter->error(new \Exception);
@@ -441,7 +441,7 @@ class Http2DriverTest extends HttpDriverTest
         EventLoop::queue(fn () => $driver->write($request, new Response(
             Status::OK,
             ["content-type" => "text/html; charset=utf-8"],
-            new PipelineStream($emitter->asPipeline())
+            new IterableStream($emitter->pipe())
         )));
 
         delay(0);
@@ -526,7 +526,7 @@ class Http2DriverTest extends HttpDriverTest
         EventLoop::queue(fn () => $driver->write($request, new Response(
             Status::OK,
             ["content-type" => "text/html; charset=utf-8"],
-            new PipelineStream($emitter->asPipeline())
+            new IterableStream($emitter->pipe())
         )));
 
         delay(0.1);
@@ -607,7 +607,7 @@ class Http2DriverTest extends HttpDriverTest
         self::assertInstanceOf(Request::class, $request);
 
         $emitter = new Emitter;
-        $writer = async(fn () => $driver->write($request, new Response(Status::OK, [], new PipelineStream($emitter->asPipeline()))));
+        $writer = async(fn () => $driver->write($request, new Response(Status::OK, [], new IterableStream($emitter->pipe()))));
 
         $emitter->emit("{data}")->ignore();
 

--- a/test/RequestBodyTest.php
+++ b/test/RequestBodyTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Server\Test;
 
-use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\ReadableBuffer;
 use Amp\Http\Server\RequestBody;
 use Amp\PHPUnit\AsyncTestCase;
 
@@ -10,7 +10,7 @@ class RequestBodyTest extends AsyncTestCase
 {
     public function testIncreaseWithoutCallback(): void
     {
-        $body = new RequestBody(new InMemoryStream("foobar"));
+        $body = new RequestBody(new ReadableBuffer("foobar"));
         $body->increaseSizeLimit(1);
         $this->assertSame("foobar", $body->buffer());
     }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Server\Test;
 
-use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\ReadableBuffer;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\Driver\Client;
 use Amp\Http\Server\MissingAttributeError;
@@ -135,9 +135,9 @@ class RequestTest extends AsyncTestCase
         self::assertSame('0', $request->getHeader('content-length'));
 
         // A stream being set MUST remove the content length header
-        $request->setBody(new InMemoryStream('foobar'));
+        $request->setBody(new ReadableBuffer('foobar'));
         self::assertFalse($request->hasHeader('content-length'));
-        $request->setBody(new InMemoryStream('foo'));
+        $request->setBody(new ReadableBuffer('foo'));
         self::assertFalse($request->hasHeader('content-length'));
 
         $request = new Request($client, 'GET', Http::createFromString('/'));

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -8,6 +8,7 @@ use Amp\Http\Status;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\PHPUnit\LoopCaughtException;
 use Amp\PHPUnit\TestException;
+use Amp\PHPUnit\UnhandledException;
 use function Amp\delay;
 
 class ResponseTest extends AsyncTestCase
@@ -21,7 +22,7 @@ class ResponseTest extends AsyncTestCase
 
     public function testDisposeThrowing(): void
     {
-        $this->expectException(LoopCaughtException::class);
+        $this->expectException(UnhandledException::class);
 
         $response = new Response;
         $response->onDispose(function () {

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -26,7 +26,7 @@ class ServerTest extends AsyncTestCase
 
     public function testShutdownWaitsOnUnfinishedResponses(): void
     {
-        $socket = Socket\Server::listen("tcp://127.0.0.1:0");
+        $socket = Socket\listen("tcp://127.0.0.1:0");
         $server = new HttpServer([$socket], new CallableRequestHandler(function () {
             delay(0.2);
             return new Response(Status::NO_CONTENT);

--- a/test/test-server.php
+++ b/test/test-server.php
@@ -27,8 +27,8 @@ $context = (new Socket\BindContext)
         ->withTlsContext((new Socket\ServerTlsContext)->withDefaultCertificate($cert));
 
 $servers = [
-        Socket\Server::listen("0.0.0.0:1338", $context),
-        Socket\Server::listen("[::]:1338", $context),
+        Socket\listen("0.0.0.0:1338", $context),
+        Socket\listen("[::]:1338", $context),
 ];
 
 $logHandler = new StreamHandler(new WritableResourceStream(STDOUT));


### PR DESCRIPTION
Made a few broad fixes on the v3 branch that get the examples running and most of the tests passing:
* `Socket\Server::listen` => `Socket\listen` as per https://github.com/amphp/socket/commit/88b0e8dee4d9eece2fd53deb6bcb088fa636a416
* `PipelineStream(new AsyncGenerator` => `IterableStream` as per https://github.com/amphp/pipeline/releases/tag/v1.0.0-beta.2 (not 100% sure if I did this right but it seems to work)
* `EmmitterStream::asPipeline()` `EmmitterStream::pipe()`
* `InMemoryStream` => `ReadableBuffer` as per https://github.com/amphp/byte-stream/releases/tag/v2.0.0-beta.1