### PR TITLE
Use static constructors for Options

### DIFF
--- a/examples/stream.php
+++ b/examples/stream.php
@@ -40,7 +40,7 @@ $server = new HttpServer($servers, new ClosureRequestHandler(function (Request $
             yield "Line {$i}\r\n";
         }
     })()));
-}), $logger, (new Options)->withoutCompression());
+}), $logger, Options::createDefault()->withoutCompression());
 
 $server->start();
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -94,7 +94,7 @@ final class HttpServer
             throw new \Error("Argument 1 can't be an empty array");
         }
 
-        $this->options = $options ?? new Options;
+        $this->options = $options ?? Options::createDefault();
         $this->timeoutCache = new TimeoutCache;
 
         if ($this->options->isCompressionEnabled()) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -25,6 +25,25 @@ final class Options
     private bool $pushEnabled = true;
     private bool $requestLogContext = false;
 
+    public static function createDefault(): self
+    {
+        return new self;
+    }
+
+    public static function createForBehindProxy(): self
+    {
+        $options = new self;
+        $options->connectionLimit = \PHP_INT_MAX;
+        $options->connectionsPerIpLimit = \PHP_INT_MAX;
+
+        return $options;
+    }
+
+    private function __construct()
+    {
+        // Private constructor to force use of static constructors.
+    }
+
     /**
      * @return bool `true` if server is in debug mode, `false` if in production mode.
      */

--- a/test/Driver/Http1DriverTest.php
+++ b/test/Driver/Http1DriverTest.php
@@ -109,7 +109,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -148,7 +148,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -199,7 +199,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -262,7 +262,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -536,7 +536,7 @@ class Http1DriverTest extends HttpDriverTest
         $msg = "dajfalkjf jslfhalsdjf\r\n\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: invalid request line";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 1 -------------------------------------------------------------------------------------->
@@ -544,7 +544,7 @@ class Http1DriverTest extends HttpDriverTest
         $msg = "test   \r\n\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: invalid request line";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 2 -------------------------------------------------------------------------------------->
@@ -556,7 +556,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 431;
         $errMsg = "Bad Request: header size violation";
-        $opts = (new Options)->withHeaderSizeLimit(128);
+        $opts = Options::createDefault()->withHeaderSizeLimit(128);
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 3 -------------------------------------------------------------------------------------->
@@ -569,7 +569,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: Invalid header syntax: Obsolete line folding";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 4 -------------------------------------------------------------------------------------->
@@ -581,7 +581,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: Invalid header syntax: Obsolete line folding";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 5 -------------------------------------------------------------------------------------->
@@ -593,7 +593,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: Invalid header syntax";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 6 -------------------------------------------------------------------------------------->
@@ -604,7 +604,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: invalid request line";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 7 -------------------------------------------------------------------------------------->
@@ -615,7 +615,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: target host mis-matched to host header";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 8 -------------------------------------------------------------------------------------->
@@ -626,7 +626,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: invalid connect target";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 9 -------------------------------------------------------------------------------------->
@@ -637,7 +637,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: authority-form only valid for CONNECT requests";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // 10 ------------------------------------------------------------------------------------->
@@ -648,7 +648,7 @@ class Http1DriverTest extends HttpDriverTest
             "\r\n";
         $errCode = 400;
         $errMsg = "Bad Request: invalid host header";
-        $opts = new Options;
+        $opts = Options::createDefault();
         $return[] = [$msg, $errCode, $errMsg, $opts];
 
         // x -------------------------------------------------------------------------------------->
@@ -670,7 +670,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            (new Options)->withBodySizeLimit(4),
+            Options::createDefault()->withBodySizeLimit(4),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -722,7 +722,7 @@ class Http1DriverTest extends HttpDriverTest
         };
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -837,7 +837,7 @@ class Http1DriverTest extends HttpDriverTest
         $data = "foobar";
 
         $driver = new Http1Driver(
-            (new Options)->withHttp1Timeout(60),
+            Options::createDefault()->withHttp1Timeout(60),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -882,7 +882,7 @@ class Http1DriverTest extends HttpDriverTest
     public function testResponseWrite(Request $request, Response $response, string $expectedRegexp, bool $expectedClosed): void
     {
         $driver = new Http1Driver(
-            (new Options)->withHttp1Timeout(60),
+            Options::createDefault()->withHttp1Timeout(60),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -947,7 +947,7 @@ class Http1DriverTest extends HttpDriverTest
     public function testWriteAbortAfterHeaders(): void
     {
         $driver = new Http1Driver(
-            (new Options)->withStreamThreshold(1), // Set stream threshold to 1 to force immediate writes to client.
+            Options::createDefault()->withStreamThreshold(1), // Set stream threshold to 1 to force immediate writes to client.
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -997,7 +997,7 @@ class Http1DriverTest extends HttpDriverTest
             "http2-settings: $settings\r\n" .
             "\r\n";
 
-        $options = (new Options)->withHttp2Upgrade();
+        $options = Options::createDefault()->withHttp2Upgrade();
 
         $expected = [
             "HTTP/1.1 101 Switching Protocols",
@@ -1041,7 +1041,7 @@ class Http1DriverTest extends HttpDriverTest
 
     public function testNativeHttp2(): void
     {
-        $options = (new Options)->withHttp2Upgrade();
+        $options = Options::createDefault()->withHttp2Upgrade();
 
         $driver = new Http1Driver(
             $options,
@@ -1079,7 +1079,7 @@ class Http1DriverTest extends HttpDriverTest
         $received = "";
 
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );
@@ -1118,7 +1118,7 @@ class Http1DriverTest extends HttpDriverTest
     public function testTrailerHeaders(): void
     {
         $driver = new Http1Driver(
-            new Options,
+            Options::createDefault(),
             $this->createMock(ErrorHandler::class),
             new NullLogger
         );

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -227,7 +227,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function setupDriver(\Closure $onMessage = null, Options $options = null): array
     {
-        $driver = new class($options ?? new Options) implements HttpDriver {
+        $driver = new class($options ?? Options::createDefault()) implements HttpDriver {
             public array $frames = [];
 
             private Http2Driver $driver;
@@ -288,7 +288,7 @@ class Http2DriverTest extends HttpDriverTest
     public function testWrite(): void
     {
         $buffer = "";
-        $options = new Options;
+        $options = Options::createDefault();
         $driver = new Http2Driver($options, new NullLogger);
         $parser = $driver->setup(
             $this->createClientMock(),
@@ -354,7 +354,7 @@ class Http2DriverTest extends HttpDriverTest
     public function testWriterAbortAfterHeaders(): void
     {
         $buffer = "";
-        $options = new Options;
+        $options = Options::createDefault();
         $driver = new Http2Driver($options, new NullLogger);
         $parser = $driver->setup(
             $this->createClientMock(),
@@ -431,7 +431,7 @@ class Http2DriverTest extends HttpDriverTest
     {
         [$driver, $parser] = $this->setupDriver(function (Request $read) use (&$request) {
             $request = $read;
-        }, (new Options)->withStreamThreshold(1)); // Set stream threshold to 1 to force immediate writes to client.
+        }, Options::createDefault()->withStreamThreshold(1)); // Set stream threshold to 1 to force immediate writes to client.
 
         $parser->send(Http2Parser::PREFACE);
 
@@ -612,7 +612,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function testClosingStreamYieldsFalseFromWriter(): void
     {
-        $driver = new Http2Driver(new Options, new NullLogger);
+        $driver = new Http2Driver(Options::createDefault(), new NullLogger);
 
         $parser = $driver->setup(
             $this->createClientMock(),
@@ -658,7 +658,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function testPush(): void
     {
-        $driver = new Http2Driver(new Options, new NullLogger);
+        $driver = new Http2Driver(Options::createDefault(), new NullLogger);
 
         $requests = [];
 
@@ -705,7 +705,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function testPingFlood(): void
     {
-        $driver = new Http2Driver(new Options, new NullLogger);
+        $driver = new Http2Driver(Options::createDefault(), new NullLogger);
 
         $client = $this->createClientMock();
         $client->expects(self::atLeastOnce())
@@ -740,7 +740,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function testTinyDataFlood(): void
     {
-        $driver = new Http2Driver(new Options, new NullLogger);
+        $driver = new Http2Driver(Options::createDefault(), new NullLogger);
 
         $client = $this->createClientMock();
         $client->expects(self::atLeastOnce())
@@ -781,7 +781,7 @@ class Http2DriverTest extends HttpDriverTest
 
     public function testSendingResponseBeforeRequestCompletes(): void
     {
-        $driver = new Http2Driver(new Options, new NullLogger);
+        $driver = new Http2Driver(Options::createDefault(), new NullLogger);
         $invoked = false;
         $parser = $driver->setup(
             $this->createClientMock(),

--- a/test/Driver/RemoteClientTest.php
+++ b/test/Driver/RemoteClientTest.php
@@ -60,7 +60,7 @@ class RemoteClientTest extends AsyncTestCase
             ),
         ];
 
-        $options = (new Options)->withDebugMode();
+        $options = Options::createDefault()->withDebugMode();
         $server = new HttpServer($servers, $handler, $this->createMock(PsrLogger::class), $options);
 
         $server->start();
@@ -279,7 +279,7 @@ class RemoteClientTest extends AsyncTestCase
         });
 
         self::assertSame(Status::NO_CONTENT, $response->getStatus());
-        self::assertSame(\implode(", ", (new Options)->getAllowedMethods()), $response->getHeader("allow"));
+        self::assertSame(\implode(", ", Options::createDefault()->getAllowedMethods()), $response->getHeader("allow"));
     }
 
     public function testError(): void
@@ -325,7 +325,7 @@ class RemoteClientTest extends AsyncTestCase
 
         $bodyData = "{data}";
 
-        $options = (new Options)
+        $options = Options::createDefault()
             ->withDebugMode();
 
         $body = $this->createMock(ReadableStream::class);
@@ -465,7 +465,7 @@ class RemoteClientTest extends AsyncTestCase
         $factory->method('selectDriver')
             ->willReturn($driver);
 
-        $options = (new Options)
+        $options = Options::createDefault()
             ->withDebugMode();
 
         [$server, $client] = Socket\createSocketPair();
@@ -509,7 +509,7 @@ class RemoteClientTest extends AsyncTestCase
         $factory->method('selectDriver')
             ->willReturn($driver);
 
-        $options = (new Options)
+        $options = Options::createDefault()
             ->withDebugMode();
 
         $client = new RemoteClient(

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -9,7 +9,7 @@ class OptionsTest extends TestCase
 {
     public function testWithDebugMode(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertFalse($options->isInDebugMode());
@@ -23,7 +23,7 @@ class OptionsTest extends TestCase
 
     public function testWithoutDebugMode(): void
     {
-        $options = (new Options)->withDebugMode();
+        $options = Options::createDefault()->withDebugMode();
 
         // default
         self::assertTrue($options->isInDebugMode());
@@ -37,7 +37,7 @@ class OptionsTest extends TestCase
 
     public function testWithConnectionLimit(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(10000, $options->getConnectionLimit());
@@ -55,7 +55,7 @@ class OptionsTest extends TestCase
 
     public function testWithConnectionsPerIpLimit(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(30, $options->getConnectionsPerIpLimit());
@@ -73,7 +73,7 @@ class OptionsTest extends TestCase
 
     public function testWithHttp1Timeout(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(15, $options->getHttp1Timeout());
@@ -91,7 +91,7 @@ class OptionsTest extends TestCase
 
     public function testWithHttp2Timeout(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(60, $options->getHttp2Timeout());
@@ -109,7 +109,7 @@ class OptionsTest extends TestCase
 
     public function testWithTlsSetupTimeout(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(5, $options->getTlsSetupTimeout());
@@ -127,7 +127,7 @@ class OptionsTest extends TestCase
 
     public function testWithBodySizeLimit(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(128 * 1024, $options->getBodySizeLimit());
@@ -145,7 +145,7 @@ class OptionsTest extends TestCase
 
     public function testWithHeaderSizeLimit(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(32768, $options->getHeaderSizeLimit());
@@ -163,7 +163,7 @@ class OptionsTest extends TestCase
 
     public function testWithConcurrentStreamLimit(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(256, $options->getConcurrentStreamLimit());
@@ -181,7 +181,7 @@ class OptionsTest extends TestCase
 
     public function testWithChunkSize(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(8192, $options->getChunkSize());
@@ -199,7 +199,7 @@ class OptionsTest extends TestCase
 
     public function testWithStreamThreshold(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(8192, $options->getStreamThreshold());
@@ -217,7 +217,7 @@ class OptionsTest extends TestCase
 
     public function testWithAllowedMethods(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertSame(["GET", "POST", "PUT", "PATCH", "HEAD", "OPTIONS", "DELETE"], $options->getAllowedMethods());
@@ -233,33 +233,33 @@ class OptionsTest extends TestCase
     {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Servers must support GET");
-        (new Options)->withAllowedMethods(["HEAD"]);
+        Options::createDefault()->withAllowedMethods(["HEAD"]);
     }
 
     public function testWithAllowedMethodsWithInvalidType(): void
     {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Invalid type at key 0 of allowed methods array: integer");
-        (new Options)->withAllowedMethods([42]);
+        Options::createDefault()->withAllowedMethods([42]);
     }
 
     public function testWithAllowedMethodsWithEmptyMethod(): void
     {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Invalid empty HTTP method");
-        (new Options)->withAllowedMethods(["HEAD", "GET", ""]);
+        Options::createDefault()->withAllowedMethods(["HEAD", "GET", ""]);
     }
 
     public function testWithAllowedMethodsWithoutHead(): void
     {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Servers must support HEAD");
-        (new Options)->withAllowedMethods(["GET"]);
+        Options::createDefault()->withAllowedMethods(["GET"]);
     }
 
     public function testWithHttpUpgrade(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertFalse($options->isHttp2UpgradeAllowed());
@@ -273,7 +273,7 @@ class OptionsTest extends TestCase
 
     public function testWithoutHttpUpgrade(): void
     {
-        $options = (new Options)->withHttp2Upgrade();
+        $options = Options::createDefault()->withHttp2Upgrade();
 
         // default
         self::assertTrue($options->isHttp2UpgradeAllowed());
@@ -287,7 +287,7 @@ class OptionsTest extends TestCase
 
     public function testWithoutPush(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertTrue($options->isPushEnabled());
@@ -301,7 +301,7 @@ class OptionsTest extends TestCase
 
     public function testWithPush(): void
     {
-        $options = (new Options)->withoutPush();
+        $options = Options::createDefault()->withoutPush();
 
         // default
         self::assertFalse($options->isPushEnabled());
@@ -315,7 +315,7 @@ class OptionsTest extends TestCase
 
     public function testWithCompression(): void
     {
-        $options = new Options;
+        $options = Options::createDefault();
 
         // default
         self::assertTrue($options->isCompressionEnabled());
@@ -329,7 +329,7 @@ class OptionsTest extends TestCase
 
     public function testWithoutCompression(): void
     {
-        $options = (new Options)->withoutCompression();
+        $options = Options::createDefault()->withoutCompression();
 
         // default
         self::assertFalse($options->isCompressionEnabled());


### PR DESCRIPTION
Similar to `Options` object in amphp/websocket.

I've found myself repeating what is in `Options::createForBehindProxy()` quite often.

A static constructor also is a little nicer DX for the fluent interface.