### PR TITLE
Fix typo in performance recommendation

### DIFF
--- a/src/Internal/PerformanceRecommender.php
+++ b/src/Internal/PerformanceRecommender.php
@@ -18,7 +18,7 @@ final class PerformanceRecommender implements ServerObserver
             if (\ini_get("zend.assertions") !== "1") {
                 $logger->warning(
                     "Running in debug mode without assertions enabled will not generate debug level " .
-                    "log messages. Enable assertions in php.ini (zend.assertions = 1) to enable" .
+                    "log messages. Enable assertions in php.ini (zend.assertions = 1) to enable " .
                     "debug logging."
                 );
             }


### PR DESCRIPTION
Fixes a minor typo of not having a space between two words due to concatination.

```diff
-Enable assertions in php.ini (zend.assertions = 1) to enabledebug logging.
+Enable assertions in php.ini (zend.assertions = 1) to enable debug logging.
```
