### PR TITLE
Fix setting buffer timeout in CompressionMiddleware

### DIFF
--- a/src/Middleware/CompressionMiddleware.php
+++ b/src/Middleware/CompressionMiddleware.php
@@ -64,6 +64,7 @@ final class CompressionMiddleware implements Middleware
         $this->minimumLength = $minimumLength;
         $this->chunkSize = $chunkSize;
         $this->contentRegex = $contentRegex;
+        $this->bufferTimeout = $bufferTimeout;
     }
 
     public function handleRequest(Request $request, RequestHandler $requestHandler): Promise


### PR DESCRIPTION
Regarding [this issue](https://github.com/amphp/http-server/issues/324), the merged change added a constructor parameter to the CompressionMiddleware, but did not set the corresponding property in the constructor. This PR rectifies that.