### PR TITLE
Fix: avoid duplicated data for streamed response

### DIFF
--- a/src/Middleware/CompressionMiddleware.php
+++ b/src/Middleware/CompressionMiddleware.php
@@ -141,6 +141,7 @@ final class CompressionMiddleware implements Middleware
                     $bodyBuffer .= $chunk = yield Promise\timeout($promise, \max(1, $expiration - Loop::now()));
 
                     if (isset($bodyBuffer[$this->minimumLength])) {
+                        $promise = $body->read();
                         break;
                     }
 


### PR DESCRIPTION
In the case of a streamed response, the content-length is null, so the bodyBuffer is filled at some point.

The problem is that some lines after it's filled again with the same data, lead to duplication (only for the first bytes).

This fix has been suggested by @trowski in #341 .

This PR fixes #341 