### PR TITLE
Add HttpErrorException

### DIFF
--- a/src/HttpErrorException.php
+++ b/src/HttpErrorException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server;
 

--- a/src/HttpErrorException.php
+++ b/src/HttpErrorException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Amp\Http\Server;
+
+final class HttpErrorException extends \Exception
+{
+    public function __construct(private readonly int $status, private readonly ?string $reason = null)
+    {
+        parent::__construct('Error ' . $status . ': ' . $reason);
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+}

--- a/src/HttpErrorException.php
+++ b/src/HttpErrorException.php
@@ -6,7 +6,7 @@ final class HttpErrorException extends \Exception
 {
     public function __construct(private readonly int $status, private readonly ?string $reason = null)
     {
-        parent::__construct('Error ' . $status . ': ' . $reason);
+        parent::__construct('Error ' . $status . ($this->reason !== null && $this->reason !== '' ? ': ' . $reason : ''));
     }
 
     public function getReason(): ?string

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -10,6 +10,7 @@ use Amp\Http\Client\StreamedContent;
 use Amp\Http\HttpStatus;
 use Amp\Http\Server\DefaultErrorHandler;
 use Amp\Http\Server\ErrorHandler;
+use Amp\Http\Server\HttpErrorException;
 use Amp\Http\Server\Request;
 use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
@@ -142,5 +143,17 @@ class IntegrationTest extends AsyncTestCase
         $response = $this->httpClient->request(new ClientRequest($this->getAuthority() . "/foo"));
 
         self::assertSame(HttpStatus::INTERNAL_SERVER_ERROR, $response->getStatus());
+    }
+
+    public function testHttpError(): void
+    {
+        $this->httpServer->start(new ClosureRequestHandler(function (Request $req) {
+            throw new HttpErrorException(401, 'test');
+        }), new DefaultErrorHandler());
+
+        $response = $this->httpClient->request(new ClientRequest($this->getAuthority() . "/foo"));
+
+        self::assertSame(401, $response->getStatus());
+        self::assertSame('test', $response->getReason());
     }
 }


### PR DESCRIPTION
This allows easier error handling and saves us e.g. from having a `FormMiddleware` in `http-server-form-parser` just for the purpose of delegating to the error handler on invalid form submissions.