### PR TITLE
Change PSR-7 to PSR-3 in middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ $middleware = new class implements Middleware {
 $stackedHandler = Middleware\stackMiddleware($requestHandler, $middleware);
 $errorHandler = new DefaultErrorHandler();
 
-// $logger is a PSR-7 logger instance.
+// $logger is a PSR-3 logger instance.
 $server = SocketHttpServer::createForDirectAccess($logger);
 $server->expose('127.0.0.1:1337');
 $server->start($stackedHandler, $errorHandler);


### PR DESCRIPTION
I think this is meant to be PSR-3 and not PSR-7, as PSR-3 is Logger interfaces and PSR-7 is HTTP message interfaces. Confused me for a quick sec.