### PR TITLE
Add `_` to host validation

### DIFF
--- a/src/Driver/Http1Driver.php
+++ b/src/Driver/Http1Driver.php
@@ -250,7 +250,7 @@ final class Http1Driver extends AbstractHttpDriver
                     throw new ClientException($this->client, "Bad Request: multiple host headers", HttpStatus::BAD_REQUEST);
                 }
 
-                if (!\preg_match("#^([A-Z\d.\-]+|\[[\d:]+])(?::([1-9]\d*))?$#i", $headers["host"][0], $matches)) {
+                if (!\preg_match("#^([A-Z\d._\-]+|\[[\d:]+])(?::([1-9]\d*))?$#i", $headers["host"][0], $matches)) {
                     throw new ClientException($this->client, "Bad Request: invalid host header", HttpStatus::BAD_REQUEST);
                 }
 
@@ -317,7 +317,7 @@ final class Http1Driver extends AbstractHttpDriver
                             );
                         }
 
-                        if (!\preg_match("#^([A-Z\d.\-]+|\[[\d:]+]):([1-9]\d*)$#i", $target, $matches)) {
+                        if (!\preg_match("#^([A-Z\d._\-]+|\[[\d:]+]):([1-9]\d*)$#i", $target, $matches)) {
                             throw new ClientException(
                                 $this->client,
                                 "Bad Request: invalid connect target",

--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -967,7 +967,7 @@ final class Http2Driver extends AbstractHttpDriver implements Http2Processor
         [':method' => $method, ':path' => $target, ':scheme' => $scheme, ':authority' => $host] = $pseudo;
         $query = null;
 
-        if (!\preg_match("#^([A-Z\d.\-]+|\[[\d:]+])(?::([1-9]\d*))?$#i", $host, $matches)) {
+        if (!\preg_match("#^([A-Z\d._\-]+|\[[\d:]+])(?::([1-9]\d*))?$#i", $host, $matches)) {
             throw new Http2StreamException(
                 "Invalid authority (host) name",
                 $streamId,


### PR DESCRIPTION
Local hosts can contain underscores. For example in Docker contexts (application/services names).