### PR TITLE
Fix method property in logger context

### DIFF
--- a/src/Driver/Internal/AbstractHttpDriver.php
+++ b/src/Driver/Internal/AbstractHttpDriver.php
@@ -113,7 +113,7 @@ abstract class AbstractHttpDriver implements HttpDriver
             ),
             [
                 'exception' => $exception,
-                'method' => $request,
+                'method' => $method,
                 'uri' => $uri,
                 'protocolVersion' => $protocolVersion,
                 'local' => $local,


### PR DESCRIPTION
Fix method property in logger context in AbstractHttpDriver::handleInternalServerError(). Should be method as string.