### PR TITLE
Fix parsing of raw ipv6 address in host header

### DIFF
--- a/src/Driver/Internal/AbstractHttpDriver.php
+++ b/src/Driver/Internal/AbstractHttpDriver.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface as PsrLogger;
 /** @internal */
 abstract class AbstractHttpDriver implements HttpDriver
 {
-    protected const HOST_HEADER_REGEX = /** @lang RegExp */ '#^([A-Z\d._\-]+|\[[\d:]+])(?::([1-9]\d*))?$#i';
+    protected const HOST_HEADER_REGEX = /** @lang RegExp */ '#^([A-Z\d._\-]+|\[[\dA-F:]+])(?::([1-9]\d*))?$#i';
 
     private static ?TimeoutQueue $timeoutQueue = null;
 


### PR DESCRIPTION
**Fixed problem:**
If you expose ipv6 and try to get access the server using a raw ipv6 address, you will get a 400 error because regexp could not parse ipv6 properly.

**Test code to reproduce**
Try to get access to `http://127.0.0.1:8085` and `http://[fe80::215:5dff:fe67:1d75]:8085` (change ipv6 to your local)

```php
use Amp\Http\Server\DefaultErrorHandler;
use Amp\Http\Server\Request;
use Amp\Http\Server\RequestHandler;
use Amp\Http\Server\Response;
use Amp\Http\Server\SocketHttpServer;
use Psr\Log\NullLogger;

$logger = new NullLogger();
$errorHandler = new DefaultErrorHandler();
$requestHandler = new class implements RequestHandler {
    public function handleRequest(Request $request) : Response
    {
        return new Response(body: 'Hello, world!');
    }
};

$server = SocketHttpServer::createForDirectAccess($logger);
$server->expose('0.0.0.0:8085');
$server->expose('[::]:8085');
$server->start($requestHandler, $errorHandler);

// Serve requests until SIGINT or SIGTERM is received by the process.
Amp\trapSignal([SIGINT, SIGTERM]);

$server->stop();
```