### PR TITLE
Fix http/2 ping flood behaviour

### DIFF
--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -1169,6 +1169,8 @@ final class Http2Driver extends AbstractHttpDriver implements Http2Processor
 
     public function handleData(int $streamId, string $data): void
     {
+        $this->pinged = 0;
+
         $length = \strlen($data);
 
         if ($streamId & 1) {

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -778,6 +778,40 @@ class Http2DriverTest extends HttpDriverTest
         );
     }
 
+    public function testIncomingDataResetsPingFloodProtection(): void
+    {
+        $buffer = Http2Parser::PREFACE;
+        $buffer .= self::packHeader([
+            ':authority' => 'localhost',
+            ':path' => '/',
+            ':scheme' => 'http',
+            ':method' => 'POST',
+        ], true);
+
+        $ping = "aaaaaaaa";
+        for ($i = 0; $i < 10; ++$i) {
+            $buffer .= self::packFrame($ping++, Http2Parser::PING, Http2Parser::NO_FLAG);
+            $buffer .= self::packFrame('a', Http2Parser::DATA, Http2Parser::NO_FLAG, 1);
+        }
+
+        $buffer .= self::packFrame('', Http2Parser::DATA, Http2Parser::END_STREAM, 1);
+
+        $this->givenInput(new ReadableBuffer($buffer));
+
+        $this->whenClientIsHandled();
+
+        $output = \bin2hex(buffer($this->output->getSource()));
+
+        self::assertStringNotContainsString(
+            \bin2hex(\pack("NN", 0, Http2Parser::ENHANCE_YOUR_CALM) . 'Too many pings'),
+            $output
+        );
+        self::assertStringContainsString(
+            \bin2hex(self::packFrame('aaaaaaaa', Http2Parser::PING, Http2Parser::ACK)),
+            $output
+        );
+    }
+
     public function testSendingResponseBeforeRequestCompletes(): void
     {
         $headers = [


### PR DESCRIPTION
Hi. I’m building a [gRPC](https://github.com/thesis-php/grpc) server with long-lived client/server/bidirectional streams.
In such streams it is normal to receive many HTTP/2 PING frames without new HEADERS, because subsequent gRPC messages are sent as DATA on an already open stream.

In `amphp/http-server`, the ping counter was effectively reset on new request headers, but not on incoming stream data. That caused active gRPC streams to be misclassified as ping abuse, eventually triggering GOAWAY (Too many pings).

My fix is to reset the ping counter when DATA is received on an active stream. Inbound DATA is valid application activity, so these pings are not an idle ping flood.