### PR TITLE
Fix HTTP/2 response body duplication on concurrent WINDOW_UPDATE

### DIFF
--- a/src/Driver/Http2Driver.php
+++ b/src/Driver/Http2Driver.php
@@ -608,23 +608,30 @@ final class Http2Driver extends AbstractHttpDriver implements Http2Processor
 
         if ($delta >= $length) {
             $this->clientWindow -= $length;
+            $stream->clientWindow -= $length;
+
+            // Clear the buffer BEFORE the suspending writeFrame() call.
+            // sendBufferedData() can be invoked via EventLoop::defer while
+            // we are suspended on the socket write (any incoming
+            // WINDOW_UPDATE schedules it). If the buffer is still
+            // populated at that point, the deferred callback re-enters
+            // writeBufferedData() and emits the same DATA frame again.
+            $bufferToWrite = $stream->buffer;
+            $stream->buffer = "";
 
             if ($length > $this->maxFrameSize) {
-                $split = \str_split($stream->buffer, $this->maxFrameSize);
-                $stream->buffer = \array_pop($split);
+                $split = \str_split($bufferToWrite, $this->maxFrameSize);
+                $bufferToWrite = \array_pop($split);
                 foreach ($split as $part) {
                     $this->writeFrame($part, Http2Parser::DATA, Http2Parser::NO_FLAG, $streamId);
                 }
             }
 
             if ($stream->state & Http2Stream::LOCAL_CLOSED) {
-                $this->writeFrame($stream->buffer, Http2Parser::DATA, Http2Parser::END_STREAM, $streamId);
+                $this->writeFrame($bufferToWrite, Http2Parser::DATA, Http2Parser::END_STREAM, $streamId);
             } else {
-                $this->writeFrame($stream->buffer, Http2Parser::DATA, Http2Parser::NO_FLAG, $streamId);
+                $this->writeFrame($bufferToWrite, Http2Parser::DATA, Http2Parser::NO_FLAG, $streamId);
             }
-
-            $stream->clientWindow -= $length;
-            $stream->buffer = "";
 
             if ($stream->deferredFuture) {
                 $stream->deferredFuture->complete();

--- a/test/Driver/Http2DriverTest.php
+++ b/test/Driver/Http2DriverTest.php
@@ -381,6 +381,142 @@ class Http2DriverTest extends HttpDriverTest
         $request->await();
     }
 
+    public function testStreamBufferIsClearedBeforeSuspendingDataWriteFrame(): void
+    {
+        /** @noinspection PhpInternalEntityUsedInspection */
+        if (HPackNghttp2::isSupported()) {
+            self::markTestSkipped('Not supported with nghttp2, disable ffi for this test.');
+        }
+
+        // The bug: writeBufferedData() used to call writeFrame() (which
+        // suspends on the underlying socket write) *before* clearing the
+        // stream's buffer. While suspended, an incoming WINDOW_UPDATE
+        // schedules EventLoop::defer($this->sendBufferedData(...)), which
+        // re-enters writeBufferedData() and -- finding the buffer still
+        // populated -- re-emits the same DATA frame.
+        //
+        // Rather than racing the fix through real timing, this test
+        // observes the invariant directly: when writeFrame() invokes
+        // writableStream->write() for a DATA frame, the corresponding
+        // stream's buffer must already be empty. The sink below records
+        // each write synchronously and snapshots $stream->buffer at that
+        // instant; pre-fix, the snapshot still contains the body.
+        $sink = new class() implements \Amp\ByteStream\WritableStream {
+            public ?\Closure $beforeWrite = null;
+
+            /** @var list<string> */
+            public array $writes = [];
+
+            private \Amp\DeferredFuture $onClose;
+
+            private bool $closed = false;
+
+            public function __construct()
+            {
+                $this->onClose = new \Amp\DeferredFuture();
+            }
+
+            public function write(string $bytes): void
+            {
+                if ($this->beforeWrite !== null) {
+                    ($this->beforeWrite)($bytes);
+                }
+                $this->writes[] = $bytes;
+            }
+
+            public function end(): void
+            {
+                $this->close();
+            }
+
+            public function close(): void
+            {
+                $this->closed = true;
+                if (!$this->onClose->isComplete()) {
+                    $this->onClose->complete();
+                }
+            }
+
+            public function isClosed(): bool
+            {
+                return $this->closed;
+            }
+
+            public function isWritable(): bool
+            {
+                return !$this->closed;
+            }
+
+            public function onClose(\Closure $onClose): void
+            {
+                $this->onClose->getFuture()->finally($onClose);
+            }
+        };
+
+        $driver = $this->driver;
+        /** @var list<array{stream:int,buffer:string}> $bufferAtDataWrite */
+        $bufferAtDataWrite = [];
+
+        $sink->beforeWrite = static function (string $bytes) use ($driver, &$bufferAtDataWrite): void {
+            if (\strlen($bytes) < 9 || \ord($bytes[3]) !== Http2Parser::DATA) {
+                return;
+            }
+            $streamId = \unpack('N', \substr($bytes, 5, 4))[1] & 0x7fffffff;
+            $streams = (fn () => $this->streams)->call($driver);
+            if (!isset($streams[$streamId])) {
+                return;
+            }
+            $bufferAtDataWrite[] = [
+                'stream' => $streamId,
+                'buffer' => $streams[$streamId]->buffer,
+            ];
+        };
+
+        $headers = [
+            ":authority" => "localhost",
+            ":path" => "/",
+            ":scheme" => "http",
+            ":method" => "GET",
+        ];
+
+        $input = Http2Parser::PREFACE
+            . self::packFrame("", Http2Parser::SETTINGS, Http2Parser::NO_FLAG)
+            . self::packHeader($headers);
+
+        $body = \str_repeat("X", 9000);
+        $this->givenNextResponse(new Response(
+            HttpStatus::OK,
+            ["content-type" => "text/plain"],
+            new ReadableBuffer($body),
+        ));
+
+        $this->driver->handleClient(
+            $this->createClientMock(),
+            new ReadableBuffer($input),
+            $sink,
+        );
+
+        $dataObservations = \array_values(\array_filter(
+            $bufferAtDataWrite,
+            static fn (array $obs): bool => $obs['stream'] === 1 && $obs['buffer'] !== '',
+        ));
+
+        self::assertNotEmpty(
+            \array_filter(
+                $bufferAtDataWrite,
+                static fn (array $obs): bool => $obs['stream'] === 1,
+            ),
+            'Driver did not emit a DATA frame for the response body on stream 1',
+        );
+
+        self::assertSame(
+            [],
+            $dataObservations,
+            'Stream buffer was still populated when writeFrame() was about to suspend; '
+            . 'a concurrent WINDOW_UPDATE-triggered sendBufferedData() would re-emit the same DATA frame.',
+        );
+    }
+
     public function testWriterAbortAfterHeaders(): void
     {
         $headers = [


### PR DESCRIPTION
## Summary

`Http2Driver::writeBufferedData()` clears `$stream->buffer` *after* the suspending `writeFrame()` call. Any `WINDOW_UPDATE` that arrives while the fiber is suspended on the underlying socket write schedules `EventLoop::defer($this->sendBufferedData(...))`, which then re-enters `writeBufferedData()` for the same stream — and, finding the buffer still populated, re-emits the same DATA frame.

Net effect for HTTP/2 responses larger than a few KB over real (TLS) sockets: the response body is delivered N+1 times, where N is the number of `WINDOW_UPDATE` frames received during the original write.

## Reproduction

A bare server returning a 9000-byte body and a `curl --http2` request reliably yield 27000 bytes on the wire (3× duplication), while the same body over HTTP/1.1 (or with HTTP/2 disabled) is delivered exactly once. JSON parsers either fail with "Extra data" or silently parse the first object and discard the rest; binary downloads silently corrupt.

A reproducer is preserved at https://github.com/wtsergo/amphp-bugs (TLS server + curl driver, side-by-side h1/h2 byte counts).

Trace from an instrumented driver, single curl request with a 9 KB body:

```
[Http2Driver] writeFrame stream=1 type=0 flags=0 data_len=9000   ← original
[Http2Driver] writeFrame stream=1 type=0 flags=0 data_len=9000   ← deferred sendBufferedData
[Http2Driver] writeFrame stream=1 type=0 flags=0 data_len=9000   ← deferred sendBufferedData
[Http2Driver] writeFrame stream=1 type=0 flags=1 data_len=0
```

## Fix

Clear `$stream->buffer` (and decrement `$stream->clientWindow`) **before** the suspending `writeFrame()` call. A re-entrant `writeBufferedData()` then sees an empty buffer and is a no-op (`sendBufferedData()` already skips streams whose buffer is empty).

The lower `if ($delta > 0)` branch already advances `$stream->buffer = \substr($data, $delta)` before its `await` and is therefore unaffected.

## Test

Added `testStreamBufferIsClearedBeforeSuspendingDataWriteFrame()` to `Http2DriverTest`. Rather than racing the bug through real timing (which the fix turns into a no-op), it asserts the invariant directly: when `writeFrame()` calls `writableStream->write()` for a DATA frame, the corresponding stream's buffer must already be empty. The test:

- fails on the unbuilt branch with "Stream buffer was still populated when writeFrame() was about to suspend";
- passes after the patch.

## Test plan

- [x] `vendor/bin/phpunit` — 126 tests, 488 assertions, all green
- [x] `vendor/bin/psalm.phar` — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] Live curl --http2 reproduction — body delivered exactly once after the patch