### PR TITLE
Close the client when the HTTP driver returns normally

### DIFF
--- a/src/SocketHttpServer.php
+++ b/src/SocketHttpServer.php
@@ -365,6 +365,7 @@ final class SocketHttpServer implements HttpServer
             try {
                 $driver->handleClient($client, $socket, $socket);
             } finally {
+                $client->close();
                 unset($this->drivers[$id]);
             }
         } catch (\Throwable $exception) {

--- a/test/SocketHttpServerTest.php
+++ b/test/SocketHttpServerTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Http\Server\Test;
+
+use Amp\ByteStream\ReadableStream;
+use Amp\ByteStream\WritableStream;
+use Amp\Http\HttpStatus;
+use Amp\Http\Server\DefaultErrorHandler;
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Driver\HttpDriver;
+use Amp\Http\Server\Driver\HttpDriverFactory;
+use Amp\Http\Server\Driver\SocketClientFactory;
+use Amp\Http\Server\ErrorHandler;
+use Amp\Http\Server\RequestHandler;
+use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
+use Amp\Http\Server\Response;
+use Amp\Http\Server\SocketHttpServer;
+use Amp\PHPUnit\AsyncTestCase;
+use Amp\Socket;
+use Psr\Log\NullLogger;
+use function Amp\delay;
+
+class SocketHttpServerTest extends AsyncTestCase
+{
+    public function testClientIsClosedWhenDriverReturns(): void
+    {
+        $driver = new class implements HttpDriver {
+            public ?Client $client = null;
+
+            public function handleClient(
+                Client $client,
+                ReadableStream $readableStream,
+                WritableStream $writableStream,
+            ): void {
+                $this->client = $client;
+                // Return normally, as a driver does when the connection ends
+                // without throwing.
+            }
+
+            public function getPendingRequestCount(): int
+            {
+                return 0;
+            }
+
+            public function getApplicationLayerProtocols(): array
+            {
+                return [];
+            }
+
+            public function stop(): void
+            {
+            }
+        };
+
+        $driverFactory = new class($driver) implements HttpDriverFactory {
+            public function __construct(private readonly HttpDriver $driver)
+            {
+            }
+
+            public function createHttpDriver(
+                RequestHandler $requestHandler,
+                ErrorHandler $errorHandler,
+                Client $client,
+            ): HttpDriver {
+                return $this->driver;
+            }
+
+            public function getApplicationLayerProtocols(): array
+            {
+                return [];
+            }
+        };
+
+        $server = new SocketHttpServer(
+            new NullLogger(),
+            new Socket\ResourceServerSocketFactory(),
+            new SocketClientFactory(new NullLogger()),
+            httpDriverFactory: $driverFactory,
+        );
+
+        $server->expose(Socket\SocketAddress\fromString('127.0.0.1:0'));
+        $server->start(
+            new ClosureRequestHandler(fn () => new Response(HttpStatus::OK)),
+            new DefaultErrorHandler(),
+        );
+
+        try {
+            $client = Socket\connect($server->getServers()[0]->getAddress()->toString());
+            $client->write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            delay(0.1);
+            $client->close();
+            delay(0.1);
+
+            self::assertNotNull($driver->client, 'Driver did not receive a client');
+            self::assertTrue(
+                $driver->client->isClosed(),
+                'Client was not closed after the driver returned; its socket and '
+                    . 'event-loop watcher leak for the lifetime of the process',
+            );
+        } finally {
+            $server->stop();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #390.

`SocketHttpServer::handleClient()` closes the client on only three paths: a failed TLS handshake, a not-yet-started server, or an exception reaching the `catch` block. When `$driver->handleClient()` returns **normally** the `finally` block merely unsets the driver from the map, and the socket is never closed:

```php
try {
    $driver->handleClient($client, $socket, $socket);
} finally {
    unset($this->drivers[$id]);   // no $client->close()
}
```

Nothing frees the descriptor afterwards. Neither `ReadableResourceStream::close()` nor `WritableResourceStream::close()` calls `fclose()` on a socket — each does `stream_socket_shutdown(SHUT_RD/SHUT_WR)` and drops its own reference, so the fd is released only once *both* halves free it and the refcount reaches zero. With no `close()` at all, the descriptor and its event-loop watcher are retained for the lifetime of the process.

The severity depends on the write queue at the moment of abandonment. In `WritableResourceStream`'s watcher `finally`, an empty queue leaves the watcher disabled (an idle leak), but a **non-empty** queue leaves it **enabled**. A dead socket is permanently writable as far as epoll is concerned, so the watcher then retries a failing write forever — measured at roughly 30k `EPIPE` writes/second per leaked descriptor.

In production this showed up as two cluster workers pinned at 100% CPU continuously for 19 days, holding 35 and 37 orphaned descriptors. The trigger is a peer that RSTs a connection sitting idle in HTTP/1.1 keep-alive, i.e. ordinary internet scanner traffic against a public listener; roughly 60% of such connections leaked in testing. After applying this change the same production deployment sits at 0% idle CPU with zero orphaned descriptors.

### Changes

- `src/SocketHttpServer.php` — close the client in the `finally`.
- `test/SocketHttpServerTest.php` — regression test using a no-op `HttpDriver` that simply returns from `handleClient()`, reproducing the same control flow deterministically (no timing race). It fails on `3.x` without the fix and passes with it.

The full suite passes (126 tests, 488 assertions).

Branched off the fork's `3.x` rather than current upstream `3.x` only to avoid touching `.github/workflows/ci.yml` (token scope); `src/SocketHttpServer.php` is identical between the two, so the diff is unaffected.
