### PR TITLE
Do not apply chunked encoding to 204/304 responses

### DIFF
--- a/src/Driver/Http1Driver.php
+++ b/src/Driver/Http1Driver.php
@@ -880,7 +880,12 @@ final class Http1Driver extends AbstractHttpDriver
             $headers["trailer"] = [\implode(", ", $fields)];
         }
 
+        // 204 and 304 responses are terminated by the end of the header section and have no
+        // body, so they must not use chunked encoding (RFC 9112 sections 6.1 and 6.3).
+        $bodyless = $status === HttpStatus::NO_CONTENT || $status === HttpStatus::NOT_MODIFIED;
+
         $chunked = !$shouldClose
+            && !$bodyless
             && (!isset($headers["content-length"]) || $trailers !== null)
             && $protocol === "1.1"
             && $status >= HttpStatus::OK;
@@ -898,7 +903,9 @@ final class Http1Driver extends AbstractHttpDriver
 
             $chunk = null; // Required for the finally, not directly overwritten, even if your IDE says otherwise.
 
-            if ($request?->getMethod() === "HEAD") {
+            if ($bodyless || $request?->getMethod() === "HEAD") {
+                $need = null; // No body is written, so nothing is owed to the client.
+
                 if ($shouldClose) {
                     $this->writableStream->end();
                 }

--- a/test/Driver/Http1DriverTest.php
+++ b/test/Driver/Http1DriverTest.php
@@ -934,11 +934,61 @@ class Http1DriverTest extends HttpDriverTest
                 "HTTP/1.0 200 OK\r\nconnection: close\r\ndate: .* GMT\r\n\r\n",
                 true,
             ],
+            [
+                "GET / HTTP/1.1",
+                new Response(HttpStatus::NO_CONTENT, ["x-custom" => "1"], new ReadableBuffer),
+                "^HTTP/1.1 204 No Content\r\nx-custom: 1\r\nconnection: keep-alive\r\nkeep-alive: timeout=60\r\ndate: .* GMT\r\n\r\n$",
+                false,
+            ],
+            [
+                "GET / HTTP/1.1",
+                new Response(HttpStatus::NOT_MODIFIED, ["etag" => "\"abc\""], new ReadableBuffer("ignored")),
+                "^HTTP/1.1 304 Not Modified\r\netag: \"abc\"\r\nconnection: keep-alive\r\nkeep-alive: timeout=60\r\ndate: .* GMT\r\n\r\n$",
+                false,
+            ],
         ];
 
         delay(0.1); // Tick event loop to complete the Trailers future.
 
         return $data;
+    }
+
+    public function testBodylessResponseDoesNotDesyncConnection(): void
+    {
+        $driver = new Http1Driver(
+            new ClosureRequestHandler(function (Request $request): Response {
+                if ($request->getUri()->getPath() === "/first") {
+                    return new Response(HttpStatus::NO_CONTENT, ["x-custom" => "1"]);
+                }
+
+                return new Response(HttpStatus::OK, [], "second");
+            }),
+            $this->createMock(ErrorHandler::class),
+            new NullLogger,
+            connectionTimeout: 60,
+        );
+
+        $output = new WritableBuffer;
+
+        async(fn () => $driver->handleClient(
+            $this->createClientMock(),
+            new ReadableBuffer(
+                "GET /first HTTP/1.1\r\nHost: test.local\r\n\r\n" .
+                "GET /second HTTP/1.1\r\nHost: test.local\r\n\r\n"
+            ),
+            $output,
+        ));
+
+        delay(0.1);
+
+        $output->close();
+
+        // The next response must start right after the header section of the bodyless one;
+        // a stray chunk terminator in between desyncs clients which stop reading at the headers.
+        self::assertMatchesRegularExpression(
+            "#^HTTP/1.1 204 No Content\r\n(?:[^\r]+\r\n)+\r\nHTTP/1.1 200 OK\r\n#",
+            $output->buffer(),
+        );
     }
 
     public function testWriteAbortAfterHeaders(): void


### PR DESCRIPTION
`Http1Driver` special-cases `HEAD` requests but not bodyless status codes: a 204 or 304 response without a `content-length` header gets `transfer-encoding: chunked` and the `0\r\n\r\n` terminator.

RFC 9112 §6.1: "A server MUST NOT send a Transfer-Encoding header field in any response with a status code of 1xx (Informational) or 204 (No Content)." Per §6.3, clients terminate 204/304 responses at the end of the header section regardless of framing headers - so the terminator bytes stay in the socket and are parsed as the start of the next response, killing the next request on the keep-alive connection. Observed against Chrome: every CORS preflight (204) poisoned its connection and the following fetch failed with a network error.

A bare `new Response(204)` is unaffected (`setBody('')` sets `content-length: 0`), but passing any header array to the constructor makes `setHeaders()` replace all headers, dropping the auto-set `content-length` - which is how adapters that copy headers from another response object hit this.

The fix excludes 204/304 from chunked encoding and skips the body write the same way `HEAD` requests already do. Setting `$need = null` in that branch also stops the `finally` block from treating the intentionally unwritten body as a truncated write and abruptly closing the connection (previously reachable with a `HEAD` response carrying a `content-length`).

**Repro** (v3.4.6, PHP 8.4):

```php
$server = SocketHttpServer::createForDirectAccess(new NullLogger());
$server->expose('127.0.0.1:1337');
$server->start(
    new ClosureRequestHandler(fn () => new Response(204, ['x-demo' => '1'])),
    new DefaultErrorHandler(),
);
```

```
$ printf 'GET / HTTP/1.1\r\nHost: l\r\nConnection: keep-alive\r\n\r\n' | nc 127.0.0.1 1337
HTTP/1.1 204 No Content
x-demo: 1
connection: keep-alive
keep-alive: timeout=15
transfer-encoding: chunked

0        <- stray bytes; a compliant client stops reading at the blank line above
```

The three added tests fail on 3.x without the driver change and pass with it; the rest of the suite, `composer code-style` and Psalm are unaffected.
